### PR TITLE
feat: Common OSLog 모듈 추가

### DIFF
--- a/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
+++ b/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-import ReactorKit
+import Util
 
 
 class SceneDelegate: UIResponder, UISceneDelegate {

--- a/24th-App-Team-1-iOS/Core/Util/Sources/Logger/WSLogger.swift
+++ b/24th-App-Team-1-iOS/Core/Util/Sources/Logger/WSLogger.swift
@@ -1,0 +1,69 @@
+//
+//  WSLogger.swift
+//  Util
+//
+//  Created by Kim dohyun on 6/27/24.
+//
+
+import Foundation
+import os.log
+
+
+//MARK: View 기반 로그 타입
+public enum ViewLogType: String, CustomStringConvertible {
+    public var description: String {
+        return "\(self.rawValue.uppercased())"
+    }
+    case login
+}
+
+public struct WSLogger {
+    
+    //MARK: Properties
+    private static let bundleId: String =  Bundle.main.bundleIdentifier ?? ""
+    
+    /// 데이터 정보를 확인할떄 사용하는 메서드 입니다.
+    /// - Parameters:
+    ///   - category: CustomStringConvertible 프로토콜을 준수한 Type이며 해당 파라메터를 통해 작은 영역을 필터링 하도록 함
+    ///   - message: 출력 할 Message를 받는 파라메터
+    public static func info(category: some CustomStringConvertible, message: String) {
+        Logger(subsystem: bundleId, category: category.description)
+            .log(level: .info, "\(message)")
+    }
+    
+    /// 코드 디버깅 용도로 사용되는 메서드 입니다.
+    /// - Parameters:
+    ///   - category: CustomStringConvertible 프로토콜을 준수한 Type이며 해당 파라메터를 통해 작은 영역을 필터링 하도록 함
+    ///   - message: 출력 할 Message를 받는 파라메터
+    public static func debug(category: some CustomStringConvertible, message: String) {
+        Logger(subsystem: bundleId, category: category.description)
+            .log(level: .debug, "\(message)")
+    }
+    
+    /// 시스템 또는 앱의 심각한 오류(크래쉬 오류)를 나타낼때 사용하는 메서드 입니다.
+    /// - Parameters:
+    ///   - category: CustomStringConvertible 프로토콜을 준수한 Type이며 해당 파라메터를 통해 작은 영역을 필터링 하도록 함
+    ///   - message: 출력 할 Message를 받는 파라메터
+    public static func fault(category: some CustomStringConvertible, message: String) {
+        Logger(subsystem: bundleId, category: category.description)
+            .log(level: .fault, "\(message)")
+    }
+    
+    /// 오류를 출력할때 사용하는 메서드 입니다.
+    /// - Parameters:
+    ///   - category: CustomStringConvertible 프로토콜을 준수한 Type이며 해당 파라메터를 통해 작은 영역을 필터링 하도록 함
+    ///   - message: 출력 할 Message를 받는 파라메터
+    public static func error(category: some CustomStringConvertible, message: String) {
+        Logger(subsystem: bundleId, category: category.description)
+            .log(level: .error, "\(message)")
+    }
+    
+    /// 일반적인 시스템 작동 중에 정보를 제공하거느 특정 이벤트를 기록하는데 사용되는 메서드 입니다.
+    /// - Parameters:
+    ///   - cateogry: CustomStringConvertible 프로토콜을 준수한 Type이며 해당 파라메터를 통해 작은 영역을 필터링 하도록 함
+    ///   - message: 출력 할 Message를 받는 파라메터
+    public static func `default`(cateogry: some CustomStringConvertible, message: String) {
+        Logger(subsystem: bundleId, category: cateogry.description)
+            .log(level: .default, "\(message)")
+    }
+}


### PR DESCRIPTION
## 작업 내용

- [x] `Util`모듈에 os.log 프레임 워크를 활용하여 `WSLogger` 모듈화를 추가하였습니다.
- [x] `ViewLogType`에 따라 Category를 지정할 수 있도록 내부 메서드를 구현 하였습니다.

## 화면 

| 코드  | 로그 |  Logger Filter | 
| :--: | :-------: | :--: |
|  <img width="719" alt="스크린샷 2024-06-27 오후 11 04 50" src="https://github.com/YAPP-Github/WeSpot-iOS/assets/23008224/74f1b8e1-62e2-4b59-b9eb-0fb3e8dd0550"> |   <img width="766" alt="스크린샷 2024-06-27 오후 11 04 43" src="https://github.com/YAPP-Github/WeSpot-iOS/assets/23008224/d2fd5414-0c36-4a1d-a646-6c05a8bfba12">     |  <img width="173" alt="스크린샷 2024-06-27 오후 11 19 17" src="https://github.com/YAPP-Github/WeSpot-iOS/assets/23008224/e1683655-045e-4e17-a59c-4fd80709d093"> |


<br/><br/><br/>
## 고민점 및 해결 방법
`WSLogger` 작업을 진행하면서 하나의 Method로 모든 Category를 구분 하려 했지만 `OSLogLevel` 마다 터미널에 제공되는 로그가 달라지기 때문에 조금더 명확하게 구분하기 위해서 `OSLogLevel`에 따라 메서드를 구분하였습니다.
- 저번 Tuist에서 `feature`, `shared`, `core`, `app` 등을 제너릭 함수를 활용해서 하나의 메서드로 구현 하려 했던 고민과 비슷 합니다.

<br/><br/><br/>
## 논의 해봤으면 좋으점
기존과 동일한 고민을 계속해서 하게되면서 위와 같은 Generic Method를 조금더 유용하게 사용하는 방법에 대해서 함께 학습하면 좋을 것 같다는 생각이 듭니다!! :)


## 참고 레퍼런스
- [OSLog](https://developer.apple.com/videos/play/wwdc2023/10226/)

<br/><br/><br/>
close: #7 
