### PR TITLE
feat: DesignSystem Module WSAlert 컴포넌트 추가

### DIFF
--- a/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Alert/WSAlertActionProperty.swift
+++ b/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Alert/WSAlertActionProperty.swift
@@ -1,0 +1,14 @@
+//
+//  WSAlertActionProperty.swift
+//  DesignSystem
+//
+//  Created by Kim dohyun on 7/9/24.
+//
+
+import Foundation
+
+//MARK: WSAlertView의 액션을 담당하는 모듈
+public struct WSAlertActionProperty {
+    var confirmAction: (() -> Void)?
+    var cancelAction: (() -> Void)?
+}

--- a/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Alert/WSAlertActionType.swift
+++ b/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Alert/WSAlertActionType.swift
@@ -1,0 +1,14 @@
+//
+//  WSAlertActionType.swift
+//  DesignSystem
+//
+//  Created by Kim dohyun on 7/9/24.
+//
+
+import Foundation
+
+//MARK: WSAlertView의 액션을 구분하기 위한 열거형 타입
+public enum WSAlertActionType {
+    case confirm
+    case cancel
+}

--- a/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Alert/WSAlertBuilder.swift
+++ b/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Alert/WSAlertBuilder.swift
@@ -1,0 +1,82 @@
+//
+//  WSAlertBuilder.swift
+//  DesignSystem
+//
+//  Created by Kim dohyun on 7/9/24.
+//
+
+import UIKit
+
+
+//MARK: WSAlertView에 모든 구성요소를 설정하는 모듈
+public final class WSAlertBuilder {
+    
+    //MARK: Properties
+    private let showViewController: UIViewController
+    private let alertViewController: WSAlertView = WSAlertView()
+    private var builderAction: WSAlertActionProperty?
+    
+    private var alertTitle: String?
+    private var alertMessage: String?
+    private var confirmText: String?
+    private var cancelText: String?
+    
+    public init(showViewController: UIViewController) {
+        self.showViewController = showViewController
+    }
+    
+    /// WSAlert의 타이틀을 설정하기 위한 메서드
+    public func setTitle(title: String) -> Self {
+        self.alertTitle = title
+        return self
+    }
+    
+    /// WSAlert의 문구를 설정하기 위한 메서드
+    public func setMessage(message: String) -> Self {
+        self.alertMessage = message
+        return self
+    }
+    
+    /// WSButton의 확인 버튼 문구를 설정하기 위한 메서드
+    public func setConfirm(text: String) -> Self {
+        self.confirmText = text
+        
+        return self
+    }
+    
+    /// WSButton의 취소 버튼 문구를 설정하기 위한 메서드
+    public func setCancel(text: String) -> Self {
+        self.cancelText = text
+        return self
+    }
+    
+    
+    /// 최종 Builder프로퍼티를 WSAlert의 적용하기 위한 메서드
+    @discardableResult
+    public func show() -> Self {
+        alertViewController.modalPresentationStyle = .overFullScreen
+        alertViewController.modalTransitionStyle = .crossDissolve
+        
+        alertViewController.titleLabel.text = alertTitle
+        alertViewController.messageLabel.text = alertMessage
+        alertViewController.confirmButton.setupButton(text: confirmText ?? "")
+        alertViewController.cancelButton.setupButton(text: cancelText ?? "")
+        
+        alertViewController.alertAction = builderAction
+        showViewController.present(alertViewController, animated: true)
+        
+        return self
+    }
+    
+    /// WSAlert Action을 설정하기 위한 메서드
+    @discardableResult
+    public func action(_ type: WSAlertActionType, action: (() -> Void)? = nil)  -> Self {
+        switch type {
+        case .confirm:
+            builderAction = WSAlertActionProperty(confirmAction: action)
+        case .cancel:
+            builderAction = WSAlertActionProperty(cancelAction: action)
+        }
+        return self
+    }
+}

--- a/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Alert/WSAlertView.swift
+++ b/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Alert/WSAlertView.swift
@@ -1,0 +1,106 @@
+//
+//  WSAlertView.swift
+//  DesignSystem
+//
+//  Created by Kim dohyun on 7/9/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+
+public final class WSAlertView: UIViewController {
+    
+    //MARK: Properties
+    private let containerView: UIView = UIView()
+    var titleLabel: WSLabel = WSLabel(wsFont: .Header01)
+    var messageLabel: WSLabel = WSLabel(wsFont: .Body06)
+    var confirmButton: WSButton = WSButton(wsButtonType: .default(10))
+    var cancelButton: WSButton = WSButton(wsButtonType: .disableButton)
+    var alertAction: WSAlertActionProperty?
+    
+    
+    private var titleText: String?
+    private var messageText: String?
+    private var confirmText: String?
+    private var cancelText: String?
+    
+    //MARK: LifeCycle
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupAutoLayout()
+        setupAttributes()
+    }
+    
+    //MARK: Configure
+    private func setupUI() {
+        view.addSubview(containerView)
+        containerView.addSubviews(titleLabel, messageLabel, confirmButton, cancelButton)
+    }
+    
+    
+    private func setupAutoLayout() {
+        
+        containerView.snp.makeConstraints {
+            $0.height.equalTo(208)
+            $0.width.equalTo(310)
+            $0.center.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(32)
+            $0.height.equalTo(32)
+            $0.centerX.equalToSuperview()
+        }
+        
+        messageLabel.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().offset(20)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.right.equalToSuperview().offset(-20)
+            $0.height.equalTo(52)
+            $0.bottom.equalToSuperview().offset(-20)
+            $0.width.equalTo(131)
+        }
+        
+        cancelButton.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(20)
+            $0.height.equalTo(52)
+            $0.bottom.equalToSuperview().offset(-20)
+            $0.width.equalTo(131)
+        }
+        
+    }
+    
+    private func setupAttributes() {
+        view.backgroundColor = .black.withAlphaComponent(0.6)
+        containerView.backgroundColor = DesignSystemAsset.Colors.gray600.color
+        containerView.layer.cornerRadius = 20
+        containerView.clipsToBounds = true
+        titleLabel.textColor = DesignSystemAsset.Colors.gray100.color
+        titleLabel.textAlignment = .center
+        messageLabel.textColor = DesignSystemAsset.Colors.gray300.color
+        
+        confirmButton.addTarget(self, action: #selector(didTapConfirmButton), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(didTapCancelButton), for: .touchUpInside)
+    }
+    
+    
+    @objc
+    private func didTapConfirmButton() {
+        self.dismiss(animated: true) { [weak self] in
+            self?.alertAction?.confirmAction?()
+        }
+    }
+    
+    @objc
+    private func didTapCancelButton() {
+        alertAction?.cancelAction?()
+        dismiss(animated: true)
+    }
+}


### PR DESCRIPTION
## 작업 내용

- [x] `Builder Pattern`을 활용하여 `WSAlertView` 구현
- [x] `WSAlertView` 모듈 추가
- [x] `WSAlertActionProperty ` 타입을 통해 `confirm`, `cancel` 액션 처리
- [x] `WSAlertActionType` 열거형 타입을 통해 `confirm`, `cancel` 타입에 따라 `WSAlertActionProperty` 에 Action 주입 하도록 코드 추가


## 화면
| | Alert |
|--------|--------|
| 화면 | <img src="https://github.com/YAPP-Github/WeSpot-iOS/assets/23008224/b1ddf8c5-a0c5-42e7-bdf4-879998be46cb" width="200"/> | 

## 실행 코드

```swift
                WSAlertBuilder(showViewController: self)
                    .setTitle(title: "야임마")
                    .setMessage(message: "자정에 상대에게 마음을 전달드릴게요\n한 번 예약한 쪽지는 전송 취소할 수 없어요 있어요")
                    .setConfirm(text: "네 예약할래요")
                    .setCancel(text: "수정할래요")
                    .action(.confirm, action: {
                         // 내부 액션 코드 추가
                    })
                    .show()

```


<br/><br/><br/>
## 고민점 및 해결 방법
- 이전에도 설정해야하는 프로퍼티가 많아지면 코드의 가독성이 떨어져서 어떻게 구현해야할까 고민한 적이 있었습니다. 
- 대체적으로 카메라 구현을 예시로 들어보면  `AVCaptureDeviceInput `, `AVCaptureDeviceOutput`, `AVCaptureVideoPreviewLayer ` 등 여러가지 프로퍼티를 설정해야하는데 이러한 프로퍼티가 늘어날수록 ViewController 에  코드 가중치가 늘어나게 되고 초기에 프로퍼티 값을 설정해줘야 하기 때문에 가독성이 떨어지게 되었습니다. 이를 방지하는 차원에서 초기에 `Builder Pattern`을 도입하게 되었습니다.


<br/><br/><br/>
close: #30 
