### PR TITLE
feat: NetWorkModule WSNetwork 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 ## User settings
 xcuserdata/
 
+## Tuist
+XCConfig/*
+
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint
 *.xccheckout

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/MonitorImpl/WSNetworkMonitor.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/MonitorImpl/WSNetworkMonitor.swift
@@ -1,0 +1,34 @@
+//
+//  WSNetworkMonitor.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+import Alamofire
+
+public final class WSNetworkMonitor: EventMonitor {
+    
+    //MARK: Property
+    public var queue: DispatchQueue = DispatchQueue(label: Bundle.main.bundleIdentifier ?? "")
+
+    //MARK: Functions
+    public func requestDidFinish(_ request: Request) {
+        print("⭐️Reqeust WSNetwork LOG⭐️")
+        print("URL : \((request.request?.url?.absoluteString ?? ""))")
+        print("Method : \((request.request?.httpMethod ?? ""))")
+        print("HTTPHeaders \((request.request?.headers) ?? .default):")
+        print("Body: \((request.request?.httpBody?.toPrettyPrintedString ?? ""))")
+    }
+    
+    
+    public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, AFError>) {
+        print("✅Response WSNetwork LOG✅")
+        print("URL : \((request.request?.url?.absoluteString ?? ""))")
+        print("Results : \((response.result))")
+        print("StatusCode : \(response.response?.statusCode ?? 0)")
+        print("Data : \(response.data?.toPrettyPrintedString ?? "")")
+    }
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/MonitorImpl/WSNetworkMonitor.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/MonitorImpl/WSNetworkMonitor.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import Alamofire
+import Util
 
 public final class WSNetworkMonitor: EventMonitor {
     
@@ -16,19 +17,19 @@ public final class WSNetworkMonitor: EventMonitor {
 
     //MARK: Functions
     public func requestDidFinish(_ request: Request) {
-        print("⭐️Reqeust WSNetwork LOG⭐️")
-        print("URL : \((request.request?.url?.absoluteString ?? ""))")
-        print("Method : \((request.request?.httpMethod ?? ""))")
-        print("HTTPHeaders \((request.request?.headers) ?? .default):")
-        print("Body: \((request.request?.httpBody?.toPrettyPrintedString ?? ""))")
+        WSLogger.debug(category: Network.default, message: "⭐️Reqeust WSNetwork LOG⭐️")
+        WSLogger.debug(category: Network.default, message: "URL : \((request.request?.url?.absoluteString ?? ""))")
+        WSLogger.debug(category: Network.default, message: "Method : \((request.request?.httpMethod ?? ""))")
+        WSLogger.debug(category: Network.default, message: "HTTPHeaders \((request.request?.headers) ?? .default):")
+        
     }
     
     
     public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, AFError>) {
-        print("✅Response WSNetwork LOG✅")
-        print("URL : \((request.request?.url?.absoluteString ?? ""))")
-        print("Results : \((response.result))")
-        print("StatusCode : \(response.response?.statusCode ?? 0)")
-        print("Data : \(response.data?.toPrettyPrintedString ?? "")")
+        WSLogger.debug(category: Network.default, message: "✅Response WSNetwork LOG✅")
+        WSLogger.debug(category: Network.default, message: "URL : \((request.request?.url?.absoluteString ?? ""))")
+        WSLogger.debug(category: Network.default, message: "Results : \((response.result))")
+        WSLogger.debug(category: Network.default, message: "StatusCode : \(response.response?.statusCode ?? 0)")
+        WSLogger.debug(category: Network.default, message: "Data : \(response.data?.toPrettyPrintedString ?? "")")
     }
 }

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/ServiceImpl/WSNetworkService.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/ServiceImpl/WSNetworkService.swift
@@ -24,7 +24,7 @@ public final class WSNetworkService: WSNetworkServiceProtocol {
     }()
     
     //MARK: Functions
-    public func requset<T: Decodable>(endPoint: URLRequestConvertible) -> Single<T> {
+    public func request<T: Decodable>(endPoint: URLRequestConvertible) -> Single<T> {
         return Single<T>.create { [weak self] single in
             let task = self?.session.request(endPoint)
                 .validate(statusCode: 200...299)

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/ServiceImpl/WSNetworkService.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/ServiceImpl/WSNetworkService.swift
@@ -1,0 +1,44 @@
+//
+//  WSNetworkService.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+import Alamofire
+import RxSwift
+
+public final class WSNetworkService: WSNetworkServiceProtocol {
+    
+    //MARK: Property
+    private let session: Session = {
+        let networkMonitor: WSNetworkMonitor = WSNetworkMonitor()
+        let networkConfigure: URLSessionConfiguration = URLSessionConfiguration.af.default
+        let networkSession: Session = Session(
+            configuration: networkConfigure,
+            eventMonitors: [networkMonitor]
+        )
+        return networkSession
+    }()
+    
+    //TODO: Status Code 값에 따른 Network 오류 처리 코드 추가
+    public func requset<T: Decodable>(endPoint: URLRequestConvertible) -> Single<T> {
+        return Single<T>.create { [weak self] single in
+            let task = self?.session.request(endPoint)
+                .validate(statusCode: 200...299)
+                .responseDecodable(of: T.self) { response in
+                    switch response.result {
+                    case let .success(response):
+                        single(.success(response))
+                    case let .failure(error):
+                        single(.failure(error))
+                    }
+                }
+            return Disposables.create {
+                task?.cancel()
+            }
+        }
+    }
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/EndPointProtocol/WSNetworkEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/EndPointProtocol/WSNetworkEndPoint.swift
@@ -10,7 +10,6 @@ import Foundation
 import Alamofire
 
 public protocol WSNetworkEndPoint: URLRequestConvertible {
-    var baseURL: String { get }
     var path: String { get }
     var method: HTTPMethod { get }
     var parameters: WSRequestParameters { get }
@@ -20,7 +19,7 @@ public protocol WSNetworkEndPoint: URLRequestConvertible {
 extension WSNetworkEndPoint {
     
     func asURLRequest() throws -> URLRequest {
-        var url = try baseURL.asURL()
+        var url = try WSNetworkConfigure.baseURL.asURL()
         var urlRequest = try URLRequest(url: url.appendingPathComponent(path), method: method)
         
         switch parameters {

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/EndPointProtocol/WSNetworkEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/EndPointProtocol/WSNetworkEndPoint.swift
@@ -1,0 +1,55 @@
+//
+//  WSNetworkEndPoint.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+import Alamofire
+
+public protocol WSNetworkEndPoint: URLRequestConvertible {
+    var baseURL: String { get }
+    var path: String { get }
+    var method: HTTPMethod { get }
+    var parameters: WSRequestParameters { get }
+}
+
+
+extension WSNetworkEndPoint {
+    
+    func asURLRequest() throws -> URLRequest {
+        var url = try baseURL.asURL()
+        var urlRequest = try URLRequest(url: url.appendingPathComponent(path), method: method)
+        
+        switch parameters {
+        case let .requestBody(body):
+            urlRequest.httpBody = try setupRequestBody(body: body)
+        case let .requestQuery(query):
+            urlRequest.url = try setupRequestQuery(url, paramters: query)
+        case let .reuqestQueryWithBody(query, body: body):
+            urlRequest.url = try setupRequestQuery(url, paramters: query)
+            urlRequest.httpBody = try setupRequestBody(body: body)
+        }
+        
+        return urlRequest
+    }
+    
+    
+    private func setupRequestQuery(_ url: URL, paramters: Encodable?) throws -> URL {
+        let params = paramters?.toDictionary() ?? [:]
+        let queryParams = params.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+        var components = URLComponents(string: url.appendingPathComponent(path).absoluteString)
+        components?.queryItems = queryParams
+        guard let originURL = components?.url else {
+            throw URLError(.badURL)
+        }
+        return originURL
+    }
+    
+    private func setupRequestBody(body: Encodable?) throws -> Data {
+        let params = body?.toDictionary() ?? [:]
+        return try JSONSerialization.data(withJSONObject: params, options: [])
+    }
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/ServiceProtocol/WSNetworkServiceProtocol.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/ServiceProtocol/WSNetworkServiceProtocol.swift
@@ -12,5 +12,5 @@ import RxSwift
 
 
 public protocol WSNetworkServiceProtocol {
-    func requset<T: Decodable>(endPoint: URLRequestConvertible) -> Single<T>
+    func request<T: Decodable>(endPoint: URLRequestConvertible) -> Single<T>
 }

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/ServiceProtocol/WSNetworkServiceProtocol.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Protocol/ServiceProtocol/WSNetworkServiceProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  WSNetworkServiceProtocol.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+import Alamofire
+import RxSwift
+
+
+public protocol WSNetworkServiceProtocol {
+    func requset<T: Decodable>(endPoint: URLRequestConvertible) -> Single<T>
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/Bundle+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/Bundle+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  Bundle+Extensions.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+
+extension Bundle {
+    static var baseURL: String {
+        guard let url = Bundle.main.object(forInfoDictionaryKey: "BASE_URL") as? String else {
+            return ""
+        }
+        return url
+    }
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/Data+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/Data+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  Data+Extensions.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+
+extension Data {
+    var toPrettyPrintedString: String? {
+        guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+              let jsonString = String(data: data, encoding: .utf8) else { return nil }
+        return jsonString
+    }
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/Encodable+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/Encodable+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  Encodable+Extensions.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+
+extension Encodable {
+    func toDictionary() -> [String: Any] {
+        guard let data = try? JSONEncoder().encode(self),
+              let jsonData = try? JSONSerialization.jsonObject(with: data),
+              let dictionaryData = jsonData as? [String: Any] else { return [:] }
+        return dictionaryData
+    }
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkConfigure.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkConfigure.swift
@@ -1,0 +1,15 @@
+//
+//  WSNetworkConfigure.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+//TODO: WSNetworkConfigure 이름은 임의로 지정한 값입니다. 논의후 변경될 수 있습니다.
+struct WSNetworkConfigure {
+    //TODO: baseURL, APIKey Hidden 숨기기
+    static let baseURL: String = ""
+    static let kakaoAPiKey: String = ""
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkConfigure.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkConfigure.swift
@@ -7,9 +7,7 @@
 
 import Foundation
 
-//TODO: WSNetworkConfigure 이름은 임의로 지정한 값입니다. 논의후 변경될 수 있습니다.
 public struct WSNetworkConfigure {
-    //TODO: baseURL, APIKey Hidden 숨기기
     public static let baseURL: String = Bundle.baseURL
     public static let kakaoAPiKey: String = ""
 }

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkConfigure.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkConfigure.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 //TODO: WSNetworkConfigure 이름은 임의로 지정한 값입니다. 논의후 변경될 수 있습니다.
-struct WSNetworkConfigure {
+public struct WSNetworkConfigure {
     //TODO: baseURL, APIKey Hidden 숨기기
-    static let baseURL: String = ""
-    static let kakaoAPiKey: String = ""
+    public static let baseURL: String = Bundle.baseURL
+    public static let kakaoAPiKey: String = ""
 }

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkError.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkError.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 public enum WSNetworkError: Error, LocalizedError {
-    case `default`(statusCode: Int)
+    case `default`(message: String)
     case badRequest(message: String)
     case unauthorized
     case forbidden

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkError.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSNetworkError.swift
@@ -1,0 +1,38 @@
+//
+//  WSNetworkError.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+
+public enum WSNetworkError: Error, LocalizedError {
+    case `default`(statusCode: Int)
+    case badRequest(message: String)
+    case unauthorized
+    case forbidden
+    case notFound
+    case conflict
+    case internalServerError
+    
+    public var errorDescription: String? {
+        switch self {
+        case let .badRequest(message):
+            return "잘못된 서버 요청으로 인한 오류가 발생하였습니다. 원인 ➡️: \(message)"
+        case .unauthorized:
+            return "인증 토큰이 만료되었습니다."
+        case .forbidden:
+            return "현재 클라이언트가 권한이 없습니다."
+        case .notFound:
+            return "요청한 리소스를 찾을 수 없습니다."
+        case .conflict:
+            return "요청한 서버가 충돌이 발생하였습니다."
+        case .internalServerError:
+            return "요청한 서버에서 문제가 발생했습니다"
+        case let .default(statusCode):
+            return "요청한 서버의 응값 값은 : \(statusCode)"
+        }
+    }
+}

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSRequestParameters.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Utils/WSRequestParameters.swift
@@ -1,0 +1,15 @@
+//
+//  WSRequestParameters.swift
+//  Networking
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import Foundation
+
+
+public enum WSRequestParameters {
+    case requestQuery(_ parameter: Encodable?)
+    case requestBody(_ parameter: Encodable?)
+    case reuqestQueryWithBody(_ query: Encodable?, body: Encodable?)
+}

--- a/24th-App-Team-1-iOS/Core/Util/Sources/Logger/WSLogger.swift
+++ b/24th-App-Team-1-iOS/Core/Util/Sources/Logger/WSLogger.swift
@@ -9,12 +9,24 @@ import Foundation
 import os.log
 
 
-//MARK: View 기반 로그 타입
-public enum ViewLogType: String, CustomStringConvertible {
+/// 기능 단위 로그 타입
+public enum Feature: String, CustomStringConvertible {
     public var description: String {
         return "\(self.rawValue.uppercased())"
     }
     case login
+}
+
+/// 네트워크 로그 타입
+public enum Network: String, CustomStringConvertible{
+    public var description: String {
+        return "\(self.rawValue.uppercased())"
+    }
+    
+    /// 에러 확인용 로그
+    case error
+    /// 데이터 출력용 로그
+    case `default`
 }
 
 public struct WSLogger {

--- a/24th-App-Team-1-iOS/Tuist/Package.swift
+++ b/24th-App-Team-1-iOS/Tuist/Package.swift
@@ -9,7 +9,11 @@ import PackageDescription
         // Customize the product types for specific package product
         // Default is .staticFramework
         // productTypes: ["Alamofire": .framework,] 
-        productTypes: [:]
+        productTypes: [:],
+        baseSettings: .settings(configurations: [
+            .debug(name: .configuration("DEV")),
+            .release(name: .configuration("PRD"))
+        ])
     )
 #endif
 

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/Configuration+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/Configuration+Templates.swift
@@ -1,0 +1,37 @@
+//
+//  Configuration+Templates.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import ProjectDescription
+
+
+public enum BuildTarget: String {
+    case dev = "DEV"
+    case prd = "PRD"
+    
+    var configurationName: ConfigurationName {
+        return .configuration(self.rawValue)
+    }
+}
+
+public extension Configuration {
+    static func build(_ type: BuildTarget, name: String = "" ) -> Self {
+        switch type {
+        case .dev:
+            return .debug(
+                name: type.configurationName,
+                xcconfig: .relativeToXCConfig(type)
+            )
+        case .prd:
+            return .release(
+                name: type.configurationName,
+                xcconfig: .relativeToXCConfig(type)
+            )
+        }
+    }
+}
+
+

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
@@ -9,7 +9,14 @@ import ProjectDescription
 
 extension InfoPlist {
     
+    public static var `default`: Self = {
+        return .extendingDefault(with: [
+            "BASE_URL": .string("https://24b0b5f1-548f-4c72-aaf9-65f747a2e62b.mock.pstmn.io/api/v1")
+        ])
+    }()
+    
     static func makeInfoPlist() -> Self {
+        
         
         var basePlist: [String: Plist.Value] = [
             "CFBundleDisplayName": .string("wespot"),
@@ -33,7 +40,8 @@ extension InfoPlist {
                 .string("Pretendard-Bold.otf"),
                 .string("Pretendard-Medium.otf"),
                 .string("Pretendard-SemiBold.otf")
-            ])
+            ]),
+            "BASE_URL": .string("https://24b0b5f1-548f-4c72-aaf9-65f747a2e62b.mock.pstmn.io/api/v1")
         ]
         
         return InfoPlist.extendingDefault(with: basePlist)

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/Path+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/Path+Templates.swift
@@ -1,0 +1,17 @@
+//
+//  Path+Templates.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by Kim dohyun on 7/10/24.
+//
+
+import ProjectDescription
+
+
+public extension Path {
+    static func relativeToXCConfig(_ type: BuildTarget) -> Self {
+        return .relativeToRoot("./XCConfig/\(type.rawValue.lowercased()).xcconfig")
+    }
+}
+
+

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -50,7 +50,12 @@ extension Project {
             organizationName: organizationName,
             options: options,
             packages: packages,
-            settings: settings,
+            settings: .settings(
+                configurations: [
+                    .build(.dev, name: name),
+                    .build(.prd, name: name)
+                ]
+            ),
             targets: targets,
             schemes: schemes,
             fileHeaderTemplate: fileHeaderTemplate,


### PR DESCRIPTION
## 작업 내용
- [x] `WSNetworkService`, `WSNetworkServiceProtocol`, `WSNetworkEndpoint` 등 각 네트워크 모듈 추가
- [x] `APIKey`, `URL`을 레포지토리에 노출 하지 못하게 `XCConfig` 파일 추가 및 `InfoPlist` Key 값 추가


## 공유 내용
- `XCConfig` 파일을 Tuist 경로에 추가했기 때문에 `App` 폴더랑 동일한 경로에 있어여 `tuist generate` 할때 오류가 발생 안합니다!!

## 논의 해봤으면 좋으점
- Network 모듈을 구현하면서 오류 처리를 어떻게 해야할지 많이 고민이 되었습니다. 
- 이 부분은 상상 코딩이긴 하지만 오류 던져주는 `DTO` 는 동일하기 때문에 `catchAndReturn` 메서드를 사용해서 오류 발생시 `ErrorDTO`를 던져주는 것이 좋을 것 같다는 생각이 들었습니다.
- 위에 말씀드린 부분이 된다 하면 굳이 statusCode로 분기 처리 구문이 필요 할까 라는 생각도 들었습니다. 테스트 삼아 API 호출 하고 싶었지만 저희 서버 API가 모두 `Token` 값이 필수라서 이 부분은 나중에 함께 고민하면 좋을 것 같습니다. 

<br/><br/><br/>
close: #32 
