### PR TITLE
fix: Template 파일 생성 명 변경

### DIFF
--- a/24th-App-Team-1-iOS/Makefile
+++ b/24th-App-Team-1-iOS/Makefile
@@ -6,22 +6,18 @@ generate:
 INSTALL_DIR := $(HOME)/Library/Developer/Xcode/Templates/feature.xctemplate
 
 # 파일 목록 지정
-FILES := templates/feature.xctemplate/___FILEBASENAME___Feature.swift \
-	templates/feature.xctemplate/___FILEBASENAME___Reactor.swift \
+FILES := templates/feature.xctemplate/___FILEBASENAME___ViewController.swift \
+	templates/feature.xctemplate/___FILEBASENAME___ViewReactor.swift \
          templates/feature.xctemplate/TemplateIcon-1016.png \
          templates/feature.xctemplate/TemplateInfo.plist
 
 # 템플릿 설치 타겟
 templates: $(FILES)
+	@echo "Template file 삭제...🫧"
+	@rm -rf $(INSTALL_DIR)
 	@echo "Template file들 설치 중 >> $(INSTALL_DIR)"
 	@mkdir -p $(INSTALL_DIR)
 	@cp -r $(FILES) $(INSTALL_DIR)
-	
-	
-# File Templates 삭제
-clean:
-	@echo "Template file 삭제...🫧"
-	@rm -rf $(INSTALL_DIR)
 
 # Makefile에서 특정 타겟이 실제 파일이나 디렉토리 이름과 상관없음 명시
-.PHONY: templates generate clean
+.PHONY: templates generate

--- a/24th-App-Team-1-iOS/Templates/feature.xctemplate/___FILEBASENAME___ViewController.swift
+++ b/24th-App-Team-1-iOS/Templates/feature.xctemplate/___FILEBASENAME___ViewController.swift
@@ -14,7 +14,7 @@ import RxSwift
 import RxCocoa
 import ReactorKit
 
-final class ___FILEBASENAMEASIDENTIFIER___: BaseViewController<Reactor> {
+final class ___FILEBASENAME___: BaseViewController<Reactor> {
 
     //MARK: - Properties
     

--- a/24th-App-Team-1-iOS/Templates/feature.xctemplate/___FILEBASENAME___ViewReactor.swift
+++ b/24th-App-Team-1-iOS/Templates/feature.xctemplate/___FILEBASENAME___ViewReactor.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import ReactorKit
 
-final class ___FILEBASENAMEASIDENTIFIER___: Reactor {
+final class ___FILEBASENAME___: Reactor {
     
     
     struct State {


### PR DESCRIPTION
## 작업 내용

- [x] ___FILEBASENAME___Feature.swift ->  ___FILEBASENAME___ViewContoller.swift 파일 명 변경
- [x] ___FILEBASENAME___Reactor.swift ->  ___FILEBASENAME___ViewReactor.swift 파일 명 변경
- [x] 파일 명 변경에 따른 makefile 명령어 수정


## 화면 

<img width="600" src="https://github.com/YAPP-Github/WeSpot-iOS/assets/108851660/07d20437-6e24-43ad-ad0f-208c91a9ffb9">
<img width="600" src="https://github.com/YAPP-Github/WeSpot-iOS/assets/108851660/0a112741-88c0-4d44-a95e-93f8af0ab3e4">
<img width="600" src="https://github.com/YAPP-Github/WeSpot-iOS/assets/108851660/9da5edc1-a8c8-4068-834a-cb072115dfd8">
<img width="600" src="https://github.com/YAPP-Github/WeSpot-iOS/assets/108851660/87706fa1-576c-421d-ac3d-f3137750e2a5">

파일 생성 과정은 이전과 동일합니다.
test 입력 시, testViewController.swift과 testViewReactor.swift 가 생성됩니다.

<br/>

## 공유 내용
**Xcode를 완전히 종료한 후, make templeates 명령어 입력 후 실행 부탁드립니다!**

<br/>

close: #37 
