### PR TITLE
fix: lineHeigth 값 1.26 조정 및 중복되는 함수 제거

### DIFF
--- a/24th-App-Team-1-iOS/Core/Extensions/Sources/NSAttributedString+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Extensions/Sources/NSAttributedString+Extensions.swift
@@ -17,7 +17,7 @@ public extension NSAttributedString {
     ///   - lineHeight: 라인 높이 배수입니다.
     ///   - textAlignment: 텍스트 정렬 방식입니다.
     /// - Returns: 생성된 NSAttributedString입니다.
-    func attributedText(text: String = "", font: UIFont, lineHeight: CGFloat, textAlignment: NSTextAlignment = .left) -> NSAttributedString {
+    func attributedText(text: String = "", font: UIFont, lineHeight: CGFloat, textAlignment: NSTextAlignment = .left, additionalAttributes: [NSAttributedString.Key: Any] = [:]) -> NSAttributedString {
         
         let paragraphStyle = NSMutableParagraphStyle()
         let lineHeightValue = font.pointSize * lineHeight
@@ -26,12 +26,14 @@ public extension NSAttributedString {
         paragraphStyle.lineHeightMultiple = lineHeight
         paragraphStyle.alignment = textAlignment
             
-        // 텍스트 베이스라인 오프셋 계산
-        let baselineOffset = (lineHeightValue - font.pointSize) / 2
         let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
             .paragraphStyle: paragraphStyle, // 문단 스타일 설정
-            .baselineOffset: baselineOffset // 베이스라인 오프셋 설정
         ]
+        
+        for (key, value) in additionalAttributes {
+            attributes[key] = value
+        }
         
         return NSAttributedString(string: text, attributes: attributes)
     }

--- a/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Font/WSFont.swift
+++ b/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/Font/WSFont.swift
@@ -97,7 +97,7 @@ public enum WSFont {
     
     
     var lineHeight: CGFloat {
-        return 1.5
+        return 1.26
     }
     
     var letterSpacing: CGFloat {

--- a/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/TextField/WSTextField.swift
+++ b/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/TextField/WSTextField.swift
@@ -100,25 +100,8 @@ public final class WSTextField: UITextField {
         self.font = wsFont.font()
         
         if let text = self.text, !text.isEmpty {
-            let attributedString = NSAttributedString(string: text, attributes: wsFontAttributes(wsFont))
-            attributedText = attributedString
+            self.attributedText = NSAttributedString.attributedText(text: text, font: wsFont.font(), lineHeight: wsFont.lineHeight, textAlignment: self.textAlignment)
         }
-    }
-    
-    private func wsFontAttributes(_ wsFont: WSFont) -> [NSAttributedString.Key: Any] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        let lineHeight = wsFont.size * wsFont.lineHeight
-        paragraphStyle.minimumLineHeight = lineHeight
-        paragraphStyle.maximumLineHeight = lineHeight
-        paragraphStyle.lineHeightMultiple = wsFont.lineHeight
-        paragraphStyle.alignment = self.textAlignment
-        
-        let baselineOffset = (lineHeight - wsFont.size) / 2
-        return [
-            .font: wsFont.font(),
-            .paragraphStyle: paragraphStyle,
-            .baselineOffset: baselineOffset
-        ]
     }
     
     // title Label 레이아웃 설정


### PR DESCRIPTION
## 작업 내용

- [x] lineHeigth 값 1.5에서 1.26으로 수정
- [x] attributtedText 함수에 [NSAttributedString.Key: Any] 매개변수를 추가


<br/>

## 부가설명

전일 논의한대로 line Height 값을 figma devmode에서 제공되는 값인 1.26으로 수정하였습니다.
attributtedText 함수에 [NSAttributedString.Key: Any] 매개변수를 추가했습니다.


<br/>

close: #61 
