### PR TITLE
feat: UserDefaults 설정 및 회원정보 적용

### DIFF
--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsManager.swift
@@ -7,6 +7,39 @@
 
 import Foundation
 
+public struct UserProfileImage: Codable {
+    var profileImage: String
+    var profileBackground: String
+    
+    public init(profileImage: String = "", profileBackground: String = "") {
+        self.profileImage = profileImage
+        self.profileBackground = profileBackground
+    }
+}
+
+public struct UserProfile: Codable {
+    var id: Int
+    var name: String
+    var gender: String
+    var introduction: String
+    var schoolName: String
+    var grade: Int
+    var classNumber: Int
+    var profileImages: UserProfileImage
+    
+    public init(id: Int = 0, name: String = "", gender: String = "", introduction: String = "", schoolName: String = "", grade: Int = 0, classNumber: Int = 0, profileImages: UserProfileImage = UserProfileImage()) {
+        self.id = id
+        self.name = name
+        self.gender = gender
+        self.introduction = introduction
+        self.schoolName = schoolName
+        self.grade = grade
+        self.classNumber = classNumber
+        self.profileImages = profileImages
+    }
+}
+
+
 public class UserDefaultsManager {
     
     public static let shared = UserDefaultsManager()
@@ -15,9 +48,20 @@ public class UserDefaultsManager {
     
     enum Key: String {
         case isAccessed // 앱에 처음 접근했는지 확인(Bool)
+        case accessToken
+        case refreshToken
+        case userProfile
     }
     
     @UserDefaultsWrapper(key: Key.isAccessed.rawValue, defaultValue: false)
        public var isAccessed: Bool
     
+    @UserDefaultsWrapper (key: Key.accessToken.rawValue, defaultValue: "")
+        public var accessToken: String
+    
+    @UserDefaultsWrapper (key: Key.refreshToken.rawValue, defaultValue: "")
+        public var refreshToken: String
+    
+    @UserDefaultsWrapper(key: Key.userProfile.rawValue, defaultValue: UserProfile())
+        public var userProfile: UserProfile
 }

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsManager.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import LoginService
+import LoginDomain
 
 public class UserDefaultsManager {
     
@@ -16,21 +16,22 @@ public class UserDefaultsManager {
     
     enum Key: String {
         case isAccessed // 앱에 처음 접근했는지 확인(Bool)
-        case accessToken
-        case refreshToken
-        case userProfile
+        case accessToken // access token
+        case refreshToken // 재발행 토큰
+        case userProfile // 사용자 프로필
+        case voteWinner
     }
     
     @UserDefaultsWrapper(key: Key.isAccessed.rawValue, defaultValue: false)
-       public var isAccessed: Bool
+       public var isAccessed: Bool?
     
     @UserDefaultsWrapper (key: Key.accessToken.rawValue, defaultValue: "")
-        public var accessToken: String
+        public var accessToken: String?
     
     @UserDefaultsWrapper(key: Key.refreshToken.rawValue, defaultValue: "")
-        public var refreshToken: String
+        public var refreshToken: String?
     
-    @UserDefaultsWrapper(key: Key.userProfile.rawValue, defaultValue: UserProfileResponseDTO(id: 0, name: "", gender: "", introduction: "", schoolName: "", grade: 0, classNumber: 0, profileImages: UserProfileImageResponseDTO(profileImage: "", profileBackground: "")))
-        public var userProfile: UserProfileResponseDTO
+    @UserDefaultsWrapper(key: Key.userProfile.rawValue, defaultValue: nil)
+        public var userProfile: UserProfileResponseEntity?
     
 }

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsManager.swift
@@ -6,39 +6,7 @@
 //
 
 import Foundation
-
-public struct UserProfileImage: Codable {
-    var profileImage: String
-    var profileBackground: String
-    
-    public init(profileImage: String = "", profileBackground: String = "") {
-        self.profileImage = profileImage
-        self.profileBackground = profileBackground
-    }
-}
-
-public struct UserProfile: Codable {
-    var id: Int
-    var name: String
-    var gender: String
-    var introduction: String
-    var schoolName: String
-    var grade: Int
-    var classNumber: Int
-    var profileImages: UserProfileImage
-    
-    public init(id: Int = 0, name: String = "", gender: String = "", introduction: String = "", schoolName: String = "", grade: Int = 0, classNumber: Int = 0, profileImages: UserProfileImage = UserProfileImage()) {
-        self.id = id
-        self.name = name
-        self.gender = gender
-        self.introduction = introduction
-        self.schoolName = schoolName
-        self.grade = grade
-        self.classNumber = classNumber
-        self.profileImages = profileImages
-    }
-}
-
+import LoginService
 
 public class UserDefaultsManager {
     
@@ -59,9 +27,10 @@ public class UserDefaultsManager {
     @UserDefaultsWrapper (key: Key.accessToken.rawValue, defaultValue: "")
         public var accessToken: String
     
-    @UserDefaultsWrapper (key: Key.refreshToken.rawValue, defaultValue: "")
+    @UserDefaultsWrapper(key: Key.refreshToken.rawValue, defaultValue: "")
         public var refreshToken: String
     
-    @UserDefaultsWrapper(key: Key.userProfile.rawValue, defaultValue: UserProfile())
-        public var userProfile: UserProfile
+    @UserDefaultsWrapper(key: Key.userProfile.rawValue, defaultValue: UserProfileResponseDTO(id: 0, name: "", gender: "", introduction: "", schoolName: "", grade: 0, classNumber: 0, profileImages: UserProfileImageResponseDTO(profileImage: "", profileBackground: "")))
+        public var userProfile: UserProfileResponseDTO
+    
 }

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsManager.swift
@@ -1,0 +1,23 @@
+//
+//  UserDefaultsManager.swift
+//  Util
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public class UserDefaultsManager {
+    
+    public static let shared = UserDefaultsManager()
+    
+    private init() {}
+    
+    enum Key: String {
+        case isAccessed // 앱에 처음 접근했는지 확인(Bool)
+    }
+    
+    @UserDefaultsWrapper(key: Key.isAccessed.rawValue, defaultValue: false)
+       public var isAccessed: Bool
+    
+}

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsWrapper.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsWrapper.swift
@@ -8,30 +8,28 @@
 import Foundation
 
 @propertyWrapper
-public struct UserDefaultsWrapper<T: Codable> {
+public struct UserDefaultsWrapper<T> {
     let key: String
-    let defaultValue: T
-    let userDefaults: UserDefaults
+    let defaultValue: T?
     
-    public init(key: String, defaultValue: T, userDefaults: UserDefaults = .standard) {
+    public init(key: String, defaultValue: T? = nil) {
         self.key = key
         self.defaultValue = defaultValue
-        self.userDefaults = userDefaults
     }
     
-    public var wrappedValue: T {
+    public var wrappedValue: T? {
         get {
-            if let data = userDefaults.data(forKey: key),
-               let value = try? JSONDecoder().decode(T.self, from: data) {
+            if let value = UserDefaults.standard.object(forKey: key) as? T {
                 return value
             }
             return defaultValue
         }
         set {
-            if let encoded = try? JSONEncoder().encode(newValue) {
-                userDefaults.set(encoded, forKey: key)
+            if let value = newValue {
+                UserDefaults.standard.set(value, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
             }
-            
         }
     }
 }

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsWrapper.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaultsWrapper.swift
@@ -1,0 +1,37 @@
+//
+//  UserDefaultsWrapper.swift
+//  Util
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+@propertyWrapper
+public struct UserDefaultsWrapper<T: Codable> {
+    let key: String
+    let defaultValue: T
+    let userDefaults: UserDefaults
+    
+    public init(key: String, defaultValue: T, userDefaults: UserDefaults = .standard) {
+        self.key = key
+        self.defaultValue = defaultValue
+        self.userDefaults = userDefaults
+    }
+    
+    public var wrappedValue: T {
+        get {
+            if let data = userDefaults.data(forKey: key),
+               let value = try? JSONDecoder().decode(T.self, from: data) {
+                return value
+            }
+            return defaultValue
+        }
+        set {
+            if let encoded = try? JSONEncoder().encode(newValue) {
+                userDefaults.set(encoded, forKey: key)
+            }
+            
+        }
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UserProfileEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UserProfileEntity.swift
@@ -1,0 +1,41 @@
+//
+//  UserProfileEntity.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/31/24.
+//
+
+import Foundation
+
+public struct UserProfileImageResponseEntity {
+    public let profileImage: String
+    public let profileBackground: String
+    
+    public init(profileImage: String, profileBackground: String) {
+        self.profileImage = profileImage
+        self.profileBackground = profileBackground
+    }
+}
+
+public struct UserProfileResponseEntity {
+    public let id: Int
+    public let name: String
+    public let gender: String
+    public let introduction: String
+    public let schoolName: String
+    public let grade: Int
+    public let classNumber: Int
+    public let profileImages: UserProfileImageResponseEntity
+    
+    public init(id: Int, name: String, gender: String, introduction: String, schoolName: String, grade: Int, classNumber: Int, profileImages: UserProfileImageResponseEntity) {
+        self.id = id
+        self.name = name
+        self.gender = gender
+        self.introduction = introduction
+        self.schoolName = schoolName
+        self.grade = grade
+        self.classNumber = classNumber
+        self.profileImages = profileImages
+    }
+}
+

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Project.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Project.swift
@@ -13,9 +13,11 @@ let loginFeature = Project.makeProject(
     targets: [
         .feature(module: .LoginFeature, dependencies: [
             .domain(module: .LoginDomain),
+            .service(module: .LoginService),
             .shared(module: .ThirdPartyLib),
             .shared(module: .DesignSystem),
-            .core(module: .Util)
+            .core(module: .Util),
+            .core(module: .Storage)
         ])
     ]
 )

--- a/24th-App-Team-1-iOS/Service/LoginService/Project.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Project.swift
@@ -12,7 +12,6 @@ let loginService = Project.makeProject(
     module: .service(.LoginService),
     targets: [
         .service(module: .LoginService, dependencies: [
-            .domain(module: .LoginDomain),
             .core(module: .Storage),
             .core(module: .Networking),
             .shared(module: .ThirdPartyLib)

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/UserProfileResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/UserProfileResponseDTO.swift
@@ -1,0 +1,55 @@
+//
+//  UserProfileResponseDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/31/24.
+//
+
+import Foundation
+
+import LoginDomain
+
+public struct UserProfileImageResponseDTO: Codable {
+    public let profileImage: String
+    public let profileBackground: String
+    
+    public init(profileImage: String, profileBackground: String) {
+        self.profileImage = profileImage
+        self.profileBackground = profileBackground
+    }
+}
+
+public struct UserProfileResponseDTO: Codable {
+    public let id: Int
+    public let name: String
+    public let gender: String
+    public let introduction: String
+    public let schoolName: String
+    public let grade: Int
+    public let classNumber: Int
+    public let profileImages: UserProfileImageResponseDTO
+    
+    public init(id: Int, name: String, gender: String, introduction: String, schoolName: String, grade: Int, classNumber: Int, profileImages: UserProfileImageResponseDTO) {
+        self.id = id
+        self.name = name
+        self.gender = gender
+        self.introduction = introduction
+        self.schoolName = schoolName
+        self.grade = grade
+        self.classNumber = classNumber
+        self.profileImages = profileImages
+    }
+}
+
+extension UserProfileImageResponseDTO {
+    func toDomain() -> UserProfileImageResponseEntity {
+        return UserProfileImageResponseEntity(profileImage: profileImage, profileBackground: profileBackground)
+    }
+}
+
+extension UserProfileResponseDTO {
+    func toDomain() -> UserProfileResponseEntity {
+        return .init(id: id, name: name, gender: gender, introduction: introduction, schoolName: schoolName, grade: grade, classNumber: classNumber, profileImages: profileImages.toDomain())
+    }
+}
+


### PR DESCRIPTION
## 작업 내용

- [x] `UserDefaultsWrapper` 프로퍼티 래퍼를 도입하여 `UserDefaults`를 단순화
- [x] 주로 이용될 기본적인 accessToken 및 UserProfile 등 기본 정의


## 부가설명
1. **UserDefaultsWrapper.swift**
    - `UserDefaultsWrapper` 프로퍼티 래퍼 추가:
      - **제네릭 프로퍼티 래퍼**를 사용해`Codable`을 준수하는 모든 타입을 지원하도록 했습니다.
      -  JSON 인코딩 및 디코딩을 통해 값을 저장하고 불러옵니다.

2. **UserDefaultsManager.swift**
    - 임의로 `UserProfileImage` 및 `UserProfile` 구조체 추가:
      - 사용자 프로필 이미지를 저장하는 `UserProfileImage`
      - 사용자 정보를 저장하는 `UserProfile`
      
    - `UserDefaultsManager` 클래스 :
      - **싱글톤 패턴**: `shared` 인스턴스를 통해 접근하도록 했습니다.
      - **키 열거형**을 이용하여`UserDefaults`에 사용될 키들을 정의합니다.


<br/>

close: #66
