### PR TITLE
feat: 로그인/회원가입 API 연동 로직 추가

### DIFF
--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/LoginEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/LoginEndPoint.swift
@@ -19,6 +19,8 @@ public enum LoginEndPoint: WSNetworkEndPoint {
     case createRefreshToken(Encodable)
     // 학교 정보 검색 API
     case fetchSchoolList(Encodable)
+    // 비속어 검색 API
+    case createProfanityCheck(Encodable)
     
     public var path: String {
         switch self {
@@ -30,6 +32,8 @@ public enum LoginEndPoint: WSNetworkEndPoint {
             return "/auth/reissue"
         case .fetchSchoolList:
             return "/auth/signup/search"
+        case .createProfanityCheck:
+            return "/messages/check-profanity"
         }
     }
     
@@ -43,6 +47,8 @@ public enum LoginEndPoint: WSNetworkEndPoint {
             return .post
         case .fetchSchoolList:
             return .get
+        case .createProfanityCheck:
+            return .post
         }
     }
     
@@ -56,6 +62,8 @@ public enum LoginEndPoint: WSNetworkEndPoint {
             return .requestBody(body)
         case .fetchSchoolList(let name):
             return .requestQuery(name)
+        case .createProfanityCheck(let messsage):
+            return .requestBody(messsage)
         }
     }
     

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/LoginEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/LoginEndPoint.swift
@@ -1,0 +1,67 @@
+//
+//  LoginEndPoint.swift
+//  Networking
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+import Alamofire
+
+public enum LoginEndPoint: WSNetworkEndPoint {
+    
+    // 소셜로그인 API
+    case createSocialLogin(Encodable)
+    // 회원가입 API
+    case createAccount(Encodable)
+    // 토큰 재발행 API
+    case createRefreshToken(Encodable)
+    // 학교 정보 검색 API
+    case fetchSchoolList(Encodable)
+    
+    public var path: String {
+        switch self {
+        case .createSocialLogin:
+            return "/auth/login"
+        case .createAccount:
+            return "/auth/signup"
+        case .createRefreshToken:
+            return "/auth/reissue"
+        case .fetchSchoolList:
+            return "/auth/signup/search"
+        }
+    }
+    
+    public var method: HTTPMethod {
+        switch self {
+        case .createSocialLogin:
+            return .post
+        case .createAccount:
+            return .post
+        case .createRefreshToken:
+            return .post
+        case .fetchSchoolList:
+            return .get
+        }
+    }
+    
+    public var parameters: WSRequestParameters {
+        switch self {
+        case .createSocialLogin(let body):
+            return .requestBody(body)
+        case .createAccount(let body):
+            return .requestBody(body)
+        case .createRefreshToken(let body):
+            return .requestBody(body)
+        case .fetchSchoolList(let name):
+            return .requestQuery(name)
+        }
+    }
+    
+    public var headers: HTTPHeaders {
+        return [
+            "Content-Type": "application/json"
+        ]
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateAccountEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateAccountEntity.swift
@@ -1,0 +1,20 @@
+//
+//  createAccountEntity.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct CreateAccountResponseEntity {
+    public let accessToken: String
+    public let refreshToken: String
+    public let refreshTokenExpiredAt: String
+    
+    public init(accessToken: String, refreshToken: String, refreshTokenExpiredAt: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.refreshTokenExpiredAt = refreshTokenExpiredAt
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateAccountRequest.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateAccountRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Consents {
+public struct ConsentsRequest {
     public let marketing: Bool
     
     public init(marketing: Bool) {
@@ -21,10 +21,10 @@ public struct CreateAccountRequest {
     public let schoolId: Int
     public let grade: Int
     public let classNumber: Int
-    public let consents: Consents
+    public let consents: ConsentsRequest
     public let signUpToken: String
     
-    public init(name: String, gender: String, schoolId: Int, grade: Int, classNumber: Int, consents: Consents, signUpToken: String) {
+    public init(name: String, gender: String, schoolId: Int, grade: Int, classNumber: Int, consents: ConsentsRequest, signUpToken: String) {
         self.name = name
         self.gender = gender
         self.schoolId = schoolId

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateAccountRequest.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateAccountRequest.swift
@@ -1,0 +1,36 @@
+//
+//  CreateAccountRequest.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct Consents {
+    public let marketing: Bool
+    
+    public init(marketing: Bool) {
+        self.marketing = marketing
+    }
+}
+
+public struct CreateAccountRequest {
+    public let name: String
+    public let gender: String
+    public let schoolId: Int
+    public let grade: Int
+    public let classNumber: Int
+    public let consents: Consents
+    public let signUpToken: String
+    
+    public init(name: String, gender: String, schoolId: Int, grade: Int, classNumber: Int, consents: Consents, signUpToken: String) {
+        self.name = name
+        self.gender = gender
+        self.schoolId = schoolId
+        self.grade = grade
+        self.classNumber = classNumber
+        self.consents = consents
+        self.signUpToken = signUpToken
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateProfanityCheckRequest.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateProfanityCheckRequest.swift
@@ -1,0 +1,16 @@
+//
+//  CreateProfanityCheckRequest.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/31/24.
+//
+
+import Foundation
+
+public struct CreateProfanityCheckRequest {
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateRefreshTokenEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateRefreshTokenEntity.swift
@@ -1,0 +1,20 @@
+//
+//  CreateRefreshToken.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct CreateRefreshTokenResponseEntity {
+    public let accessToken: String
+    public let refreshToken: String
+    public let refreshTokenExpiredAt:String
+    
+    public init(accessToken: String, refreshToken: String, refreshTokenExpiredAt: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.refreshTokenExpiredAt = refreshTokenExpiredAt
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateRefreshTokenRequest.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateRefreshTokenRequest.swift
@@ -1,0 +1,16 @@
+//
+//  CreateRefreshTokenRequest.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct CreateRefreshTokenRequest {
+    public let token: String
+    
+    public init(token: String) {
+        self.token = token
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateSignUpTokenEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateSignUpTokenEntity.swift
@@ -1,0 +1,16 @@
+//
+//  CreateSignUpToken.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct CreateSignUpTokenResponseEntity {
+    public let signUpToken: String
+    
+    public init(signUpToken: String) {
+        self.signUpToken = signUpToken
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateSignUpTokenRequest.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateSignUpTokenRequest.swift
@@ -1,0 +1,22 @@
+//
+//  CreateSignUpTokenRuquestToken.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct CreateSignUpTokenRequest {
+    public let socialType: String
+    public let authorizationCode: String
+    public let identityToken: String
+    public let fcmToken: String
+    
+    public init(socialType: String, authorizationCode: String, identityToken: String, fcmToken: String) {
+        self.socialType = socialType
+        self.authorizationCode = authorizationCode
+        self.identityToken = identityToken
+        self.fcmToken = fcmToken
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/SchoolListEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/SchoolListEntity.swift
@@ -1,0 +1,39 @@
+//
+//  SchoolListEntity.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct SchoolListResponseEntity {
+    public let schools: [SchoolListEntity]
+    
+    public init(schools: [SchoolListEntity]) {
+        self.schools = schools
+    }
+}
+
+
+// 학교 검색 API
+public enum SchoolType: String {
+    case middle = "중학교"
+    case high = "고등학교"
+}
+
+public struct SchoolListEntity {
+    public let id: Int
+    public let name: String
+    public let address: String
+    public let type: SchoolType
+    
+    public init(id: Int, name: String, address: String, type: SchoolType) {
+        self.id = id
+        self.name = name
+        self.address = address
+        self.type = type
+    }
+}
+
+

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/SchoolListRequestQuery.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/SchoolListRequestQuery.swift
@@ -1,0 +1,16 @@
+//
+//  FetchSchoolListRequestQuery.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct SchoolListRequestQuery {
+    public let name: String
+    
+    public init(name: String) {
+        self.name = name
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Repositories/LoginRepositoryProtocol.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Repositories/LoginRepositoryProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  LoginRepositoryProtocol.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+import RxSwift
+
+public protocol LoginRepositoryProtocol {
+    func createSignUpToken(body: CreateSignUpTokenRequest) -> Single<CreateSignUpTokenResponseEntity?> // 신규회원 signUp Token 발행
+    func createAccount(body: CreateAccountRequest) -> Single<CreateAccountResponseEntity?> //회원가입
+    func createRefreshToken(body: CreateRefreshTokenRequest) -> Single<CreateRefreshTokenResponseEntity?> // 토큰 재발행
+    func fetchSchoolList(query: SchoolListRequestQuery) -> Single<SchoolListResponseEntity?> // 학교 검색
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Repositories/LoginRepositoryProtocol.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Repositories/LoginRepositoryProtocol.swift
@@ -14,4 +14,5 @@ public protocol LoginRepositoryProtocol {
     func createAccount(body: CreateAccountRequest) -> Single<CreateAccountResponseEntity?> //회원가입
     func createRefreshToken(body: CreateRefreshTokenRequest) -> Single<CreateRefreshTokenResponseEntity?> // 토큰 재발행
     func fetchSchoolList(query: SchoolListRequestQuery) -> Single<SchoolListResponseEntity?> // 학교 검색
+    func createProfanityCheck(body: CreateProfanityCheckRequest) -> Single<Void?>
 }

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateAccountUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateAccountUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  CreateAccountUseCase.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+public protocol CreateAccountUseCaseProtocol {
+    func execute(body: CreateAccountRequest) -> Single<CreateAccountResponseEntity?>
+}
+
+public final class CreateAccountUseCase: CreateAccountUseCaseProtocol {
+
+    public let loginRepository: LoginRepositoryProtocol
+    
+    public init(loginRepository: LoginRepositoryProtocol) {
+        self.loginRepository = loginRepository
+    }
+
+    public func execute(body: CreateAccountRequest) -> Single<CreateAccountResponseEntity?> {
+        return loginRepository.createAccount(body: body)
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateProfanityCheckUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateProfanityCheckUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  CreateProfanityCheckUseCase.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/31/24.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+public protocol createProfanityCheckUseCaseProtocol {
+    func execute(body: CreateProfanityCheckRequest) -> Single<Void?>
+}
+
+
+public final class createProfanityCheckUseCase: createProfanityCheckUseCaseProtocol {
+    
+    
+    public let loginRepository: LoginRepositoryProtocol
+    
+    public init(loginRepository: LoginRepositoryProtocol) {
+        self.loginRepository = loginRepository
+    }
+
+    public func execute(body: CreateProfanityCheckRequest) -> Single<Void?> {
+        return loginRepository.createProfanityCheck(body: body)
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateRefreshTokenUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateRefreshTokenUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  CreateRefreshTokenUseCase.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+public protocol CreateRefreshTokenUseCaseProtocol {
+    func execute(body: CreateRefreshTokenRequest) -> Single<CreateRefreshTokenResponseEntity?>
+}
+
+public final class createRefreshTokenUseCase: CreateRefreshTokenUseCaseProtocol {
+
+    public let loginRepository: LoginRepositoryProtocol
+    
+    public init(loginRepository: LoginRepositoryProtocol) {
+        self.loginRepository = loginRepository
+    }
+
+    public func execute(body: CreateRefreshTokenRequest) -> Single<CreateRefreshTokenResponseEntity?> {
+        return loginRepository.createRefreshToken(body: body)
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateSignUpTokenUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateSignUpTokenUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  CreateSignUpTokenUseCase.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+public protocol CreateSignUpTokenUseCaseProtocol {
+    func execute(body: CreateSignUpTokenRequest) -> Single<CreateSignUpTokenResponseEntity?>
+}
+
+public final class createSignUpTokenUseCase: CreateSignUpTokenUseCaseProtocol {
+
+    
+    public let loginRepository: LoginRepositoryProtocol
+    
+    public init(loginRepository: LoginRepositoryProtocol) {
+        self.loginRepository = loginRepository
+    }
+
+    public func execute(body: CreateSignUpTokenRequest) -> Single<CreateSignUpTokenResponseEntity?> {
+        return loginRepository.createSignUpToken(body: body)
+    }
+    
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/FetchSchoolListUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/FetchSchoolListUseCase.swift
@@ -1,0 +1,28 @@
+//
+//  FetchSchoolListUseCase.swift
+//  LoginDomain
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+public protocol FetchSchoolListUseCaseProtocol {
+    func execute(query: SchoolListRequestQuery) -> Single<SchoolListResponseEntity?>
+}
+
+public final class FetchSchoolListUseCase: FetchSchoolListUseCaseProtocol {
+    
+    public let loginRepository: LoginRepositoryProtocol
+    
+    public init(loginRepository: LoginRepositoryProtocol) {
+        self.loginRepository = loginRepository
+    }
+
+    public func execute(query: SchoolListRequestQuery) -> Single<SchoolListResponseEntity?> {
+        return loginRepository.fetchSchoolList(query: query)
+    }
+}

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Project.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Project.swift
@@ -13,9 +13,11 @@ let loginFeature = Project.makeProject(
     targets: [
         .feature(module: .LoginFeature, dependencies: [
             .domain(module: .LoginDomain),
+            .service(module: .LoginService),
             .shared(module: .ThirdPartyLib),
             .shared(module: .DesignSystem),
-            .core(module: .Util)
+            .core(module: .Util),
+            .core(module: .Storage)
         ])
     ]
 )

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/SignInViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/SignInViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Util
+import Storage
 import DesignSystem
 
 import Then
@@ -30,6 +31,12 @@ public final class SignInViewController: BaseViewController<SignInViewReactor> {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        UserDefaultsManager.shared.isAccessed = true
     }
     
     //MARK: - Configure

--- a/24th-App-Team-1-iOS/Service/LoginService/Project.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Project.swift
@@ -12,7 +12,6 @@ let loginService = Project.makeProject(
     module: .service(.LoginService),
     targets: [
         .service(module: .LoginService, dependencies: [
-            .domain(module: .LoginDomain),
             .core(module: .Storage),
             .core(module: .Networking),
             .shared(module: .ThirdPartyLib)

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountRequestDTO.swift
@@ -16,6 +16,15 @@ public struct CreateAccountRequestDTO: Encodable {
     public let consents: ConsentsRequestDTO
     public let signUpToken: String
     
+    public init(name: String, gender: String, schoolId: Int, grade: Int, classNumber: Int, consents: ConsentsRequestDTO, signUpToken: String) {
+        self.name = name
+        self.gender = gender
+        self.schoolId = schoolId
+        self.grade = grade
+        self.classNumber = classNumber
+        self.consents = consents
+        self.signUpToken = signUpToken
+    }
 }
 
 public struct ConsentsRequestDTO: Encodable {

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountRequestDTO.swift
@@ -13,21 +13,12 @@ public struct CreateAccountRequestDTO: Encodable {
     public let schoolId: Int
     public let grade: Int
     public let classNumber: Int
-    public let consents: Consents
+    public let consents: ConsentsRequestDTO
     public let signUpToken: String
     
-    public init(name: String, gender: String, schoolId: Int, grade: Int, classNumber: Int, consents: Consents, signUpToken: String) {
-        self.name = name
-        self.gender = gender
-        self.schoolId = schoolId
-        self.grade = grade
-        self.classNumber = classNumber
-        self.consents = consents
-        self.signUpToken = signUpToken
-    }
 }
 
-public struct Consents: Encodable {
+public struct ConsentsRequestDTO: Encodable {
     public let marketing: Bool
     
     public init(marketing: Bool) {

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountRequestDTO.swift
@@ -1,0 +1,36 @@
+//
+//  CreateAccountRequestDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct CreateAccountRequestDTO: Encodable {
+    public let name: String
+    public let gender: String
+    public let schoolId: Int
+    public let grade: Int
+    public let classNumber: Int
+    public let consents: Consents
+    public let signUpToken: String
+    
+    public init(name: String, gender: String, schoolId: Int, grade: Int, classNumber: Int, consents: Consents, signUpToken: String) {
+        self.name = name
+        self.gender = gender
+        self.schoolId = schoolId
+        self.grade = grade
+        self.classNumber = classNumber
+        self.consents = consents
+        self.signUpToken = signUpToken
+    }
+}
+
+public struct Consents: Encodable {
+    public let marketing: Bool
+    
+    public init(marketing: Bool) {
+        self.marketing = marketing
+    }
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountResponseDTO.swift
@@ -1,0 +1,28 @@
+//
+//  CreateAccountResponseDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+import LoginDomain
+
+public struct CreateAccountResponseDTO: Decodable {
+    public let accessToken: String
+    public let refreshToken: String
+    public let refreshTokenExpiredAt: String
+    
+    public init(accessToken: String, refreshToken: String, refreshTokenExpiredAt: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.refreshTokenExpiredAt = refreshTokenExpiredAt
+    }
+}
+
+
+extension CreateAccountResponseDTO {
+    func toDomain() -> CreateAccountResponseEntity {
+        return .init(accessToken: accessToken, refreshToken: refreshToken, refreshTokenExpiredAt: refreshTokenExpiredAt)
+    }
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateAccountResponseDTO.swift
@@ -13,11 +13,6 @@ public struct CreateAccountResponseDTO: Decodable {
     public let refreshToken: String
     public let refreshTokenExpiredAt: String
     
-    public init(accessToken: String, refreshToken: String, refreshTokenExpiredAt: String) {
-        self.accessToken = accessToken
-        self.refreshToken = refreshToken
-        self.refreshTokenExpiredAt = refreshTokenExpiredAt
-    }
 }
 
 

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateProfanityCheckRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateProfanityCheckRequestDTO.swift
@@ -10,7 +10,4 @@ import Foundation
 public struct CreateProfanityCheckRequestDTO: Decodable {
     public let message: String
     
-    public init(message: String) {
-        self.message = message
-    }
 }

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateProfanityCheckRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateProfanityCheckRequestDTO.swift
@@ -10,4 +10,7 @@ import Foundation
 public struct CreateProfanityCheckRequestDTO: Decodable {
     public let message: String
     
+    public init(message: String) {
+        self.message = message
+    }
 }

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateProfanityCheckRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateProfanityCheckRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  CreateProfanityCheckRequestDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/31/24.
+//
+
+import Foundation
+
+public struct CreateProfanityCheckRequestDTO: Decodable {
+    public let message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenRequestDTO.swift
@@ -11,4 +11,7 @@ import LoginDomain
 public struct CreateRefreshTokenRequestDTO: Encodable {
     public let token: String
    
+    public init(token: String) {
+        self.token = token
+    }
 }

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenRequestDTO.swift
@@ -10,8 +10,5 @@ import LoginDomain
 
 public struct CreateRefreshTokenRequestDTO: Encodable {
     public let token: String
-    
-    public init(token: String) {
-        self.token = token
-    }
+   
 }

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenRequestDTO.swift
@@ -1,0 +1,17 @@
+//
+//  CreateRefreshTokenRequestDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+import LoginDomain
+
+public struct CreateRefreshTokenRequestDTO: Encodable {
+    public let token: String
+    
+    public init(token: String) {
+        self.token = token
+    }
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenResponseDTO.swift
@@ -1,0 +1,27 @@
+//
+//  CreateRefreshTokenResponseDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+import LoginDomain
+
+public struct CreateRefreshTokenResponseDTO: Decodable {
+    public let accessToken: String
+    public let refreshToken: String
+    public let refreshTokenExpiredAt:String
+    
+    public init(accessToken: String, refreshToken: String, refreshTokenExpiredAt: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        self.refreshTokenExpiredAt = refreshTokenExpiredAt
+    }
+}
+
+extension CreateRefreshTokenResponseDTO {
+    func toDomain() -> CreateRefreshTokenResponseEntity {
+        return .init(accessToken: accessToken, refreshToken: refreshToken, refreshTokenExpiredAt: refreshTokenExpiredAt)
+    }
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateRefreshTokenResponseDTO.swift
@@ -13,11 +13,6 @@ public struct CreateRefreshTokenResponseDTO: Decodable {
     public let refreshToken: String
     public let refreshTokenExpiredAt:String
     
-    public init(accessToken: String, refreshToken: String, refreshTokenExpiredAt: String) {
-        self.accessToken = accessToken
-        self.refreshToken = refreshToken
-        self.refreshTokenExpiredAt = refreshTokenExpiredAt
-    }
 }
 
 extension CreateRefreshTokenResponseDTO {

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenRequestDTO.swift
@@ -12,4 +12,11 @@ public struct CreateSignUpTokenRequestDTO: Encodable {
     public let authorizationCode: String
     public let identityToken: String
     public let fcmToken: String
+    
+    public init(socialType: String, authorizationCode: String, identityToken: String, fcmToken: String) {
+        self.socialType = socialType
+        self.authorizationCode = authorizationCode
+        self.identityToken = identityToken
+        self.fcmToken = fcmToken
+    }
 }

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenRequestDTO.swift
@@ -12,11 +12,4 @@ public struct CreateSignUpTokenRequestDTO: Encodable {
     public let authorizationCode: String
     public let identityToken: String
     public let fcmToken: String
-    
-    public init(socialType: String, authorizationCode: String, identityToken: String, fcmToken: String) {
-        self.socialType = socialType
-        self.authorizationCode = authorizationCode
-        self.identityToken = identityToken
-        self.fcmToken = fcmToken
-    }
 }

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenRequestDTO.swift
@@ -1,0 +1,22 @@
+//
+//  CreateSignUpTokenRequestDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct CreateSignUpTokenRequestDTO: Encodable {
+    public let socialType: String
+    public let authorizationCode: String
+    public let identityToken: String
+    public let fcmToken: String
+    
+    public init(socialType: String, authorizationCode: String, identityToken: String, fcmToken: String) {
+        self.socialType = socialType
+        self.authorizationCode = authorizationCode
+        self.identityToken = identityToken
+        self.fcmToken = fcmToken
+    }
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenResponseDTO.swift
@@ -1,0 +1,24 @@
+//
+//  CreateSignUpTokenResponseDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+import LoginDomain
+
+public struct CreateSignUpTokenResponseDTO: Decodable {
+    public let signUpToken: String
+    
+    public init(signUpToken: String) {
+        self.signUpToken = signUpToken
+    }
+}
+
+
+extension CreateSignUpTokenResponseDTO {
+    func toDomain() -> CreateSignUpTokenResponseEntity {
+        return .init(signUpToken: signUpToken)
+    }
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateSignUpTokenResponseDTO.swift
@@ -10,10 +10,7 @@ import LoginDomain
 
 public struct CreateSignUpTokenResponseDTO: Decodable {
     public let signUpToken: String
-    
-    public init(signUpToken: String) {
-        self.signUpToken = signUpToken
-    }
+
 }
 
 

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/SchoolListRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/SchoolListRequestDTO.swift
@@ -10,6 +10,9 @@ import Foundation
 public struct SchoolListRequestDTO: Encodable {
     public let name: String
 
+    init(name: String) {
+        self.name = name
+    }
 }
 
 

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/SchoolListRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/SchoolListRequestDTO.swift
@@ -9,10 +9,7 @@ import Foundation
 
 public struct SchoolListRequestDTO: Encodable {
     public let name: String
-    
-    public init(name: String) {
-        self.name = name
-    }
+
 }
 
 

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/SchoolListRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/SchoolListRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  SchoolRequestDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+public struct SchoolListRequestDTO: Encodable {
+    public let name: String
+    
+    public init(name: String) {
+        self.name = name
+    }
+}
+
+

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/SchoolListResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/SchoolListResponseDTO.swift
@@ -1,0 +1,41 @@
+//
+//  SchoolListResponseDTO.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+
+import LoginDomain
+
+public struct SchoolListResponseDTO: Decodable {
+    public let schools: [SchoolListEntityDTO]
+}
+
+public struct SchoolListEntityDTO: Decodable {
+    public let id: Int
+    public let name: String
+    public let address: String
+    public let type: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case address
+        case type
+    }
+}
+
+
+extension SchoolListResponseDTO {
+    func toDomain() -> SchoolListResponseEntity {
+        return .init(schools: schools.map { $0.toDomain() })
+    }
+}
+
+extension SchoolListEntityDTO {
+    func toDomain() -> SchoolListEntity {
+        return .init(id: id, name: name, address: address, type: SchoolType(rawValue: type) ?? .middle)
+    }
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/Repository/LoginRepository.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/Repository/LoginRepository.swift
@@ -1,0 +1,72 @@
+//
+//  LoginRepository.swift
+//  LoginService
+//
+//  Created by eunseou on 7/30/24.
+//
+
+import Foundation
+import Networking
+import LoginDomain
+import Util
+import Extensions
+
+import RxSwift
+import RxCocoa
+
+public final class LoginRepository: LoginRepositoryProtocol {
+   
+    private let networkService: WSNetworkServiceProtocol = WSNetworkService()
+    
+    public init() { }
+    
+    public func createSignUpToken(body: CreateSignUpTokenRequest) -> Single<LoginDomain.CreateSignUpTokenResponseEntity?> {
+        let body = CreateSignUpTokenRequestDTO(socialType: body.socialType, authorizationCode: body.authorizationCode, identityToken: body.identityToken, fcmToken: body.fcmToken)
+        let endPoint = LoginEndPoint.createSocialLogin(body)
+        
+        return networkService.request(endPoint: endPoint)
+            .asObservable()
+            .logErrorIfDetected(category: Network.error)
+            .decodeMap(CreateSignUpTokenResponseDTO.self)
+            .map { $0.toDomain() }
+            .asSingle()
+    }
+    
+    public func createAccount(body: CreateAccountRequest) -> Single<CreateAccountResponseEntity?> {
+        let consents = Consents(marketing: body.consents.marketing)
+        let body = CreateAccountRequestDTO(name: body.name, gender: body.gender, schoolId: body.schoolId, grade: body.grade, classNumber: body.classNumber, consents: consents, signUpToken: body.signUpToken)
+        let endPoint = LoginEndPoint.createAccount(body)
+        
+        return networkService.request(endPoint: endPoint)
+            .asObservable()
+            .logErrorIfDetected(category: Network.error)
+            .decodeMap(CreateAccountResponseDTO.self)
+            .map { $0.toDomain() }
+            .asSingle()
+    }
+    
+    public func createRefreshToken(body: CreateRefreshTokenRequest) -> Single<CreateRefreshTokenResponseEntity?> {
+        let body = CreateRefreshTokenRequestDTO(token: body.token)
+        let endPoint = LoginEndPoint.createRefreshToken(body)
+        
+        return networkService.request(endPoint: endPoint)
+            .asObservable()
+            .logErrorIfDetected(category: Network.error)
+            .decodeMap(CreateRefreshTokenResponseDTO.self)
+            .map { $0.toDomain() }
+            .asSingle()
+    }
+    
+    public func fetchSchoolList(query: SchoolListRequestQuery) -> Single<SchoolListResponseEntity?> {
+        let query = SchoolListRequestDTO(name: query.name)
+        let endPoint = LoginEndPoint.fetchSchoolList(query)
+        
+        return networkService.request(endPoint: endPoint)
+            .asObservable()
+            .logErrorIfDetected(category: Network.error)
+            .decodeMap(SchoolListResponseDTO.self)
+            .map { $0.toDomain() }
+            .asSingle()
+    }
+    
+}

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/Repository/LoginRepository.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/Repository/LoginRepository.swift
@@ -69,4 +69,13 @@ public final class LoginRepository: LoginRepositoryProtocol {
             .asSingle()
     }
     
+    public func createProfanityCheck(body: CreateProfanityCheckRequest) -> Single<Void?> {
+        let query = CreateProfanityCheckRequestDTO(message: body.message)
+        let endPoint = LoginEndPoint.createProfanityCheck(query)
+        
+        return networkService.request(endPoint: endPoint)
+            .asObservable()
+            .logErrorIfDetected(category: Network.error)
+            .asSingle()
+    }
 }


### PR DESCRIPTION
## 작업 내용
- [x] `소셜로그인 API`, `회원가입 API`, `토큰 재발행 API`, `회원가입-학교검색 API`, `비속어 check API` Domain 레이어에 Entity 추가
- [x] `소셜로그인 API`, `회원가입 API`, `토큰 재발행 API`, `회원가입-학교검색 API`, `비속어 check API` Domain 레이어에 UseCase 추가
- [x] `소셜로그인 API`, `회원가입 API`, `토큰 재발행 API`, `회원가입-학교검색 API`, `비속어 check API` Service 레이어에 DTO 추가
- [x] `소셜로그인 API`, `회원가입 API`, `토큰 재발행 API`, `회원가입-학교검색 API`, `비속어 check API` Service 레이어에 Repository 구현

<br/>

## 부가설명
 Domain, Service 모듈에 기본적인 DTO, Entity, UseCase, Repository

close: #67
