### PR TITLE
feat: 투표 인스타 공유하기 기능 추가 

### DIFF
--- a/24th-App-Team-1-iOS/Core/Extensions/Sources/UIView+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Extensions/Sources/UIView+Extensions.swift
@@ -16,6 +16,13 @@ public extension UIView {
             addSubview($0)
         }
     }
+    
+    func asImage() -> UIImage {
+        let render = UIGraphicsImageRenderer(bounds: bounds)
+        return render.image { renderContext in
+            layer.render(in: renderContext.cgContext)
+        }
+    }
 }
 
 public extension Reactive where Base: UITapGestureRecognizer {

--- a/24th-App-Team-1-iOS/Core/Extensions/Sources/UIViewController+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Extensions/Sources/UIViewController+Extensions.swift
@@ -21,4 +21,26 @@ public extension UIViewController {
     @objc func dismissKeyboard() {
         view.endEditing(true)
     }
+    
+    func shareToInstagramStory(to view: UIView) {
+        guard let url = URL(string: "instagram-stories://share?source_application="+"123444") else { return }
+        
+        view.setNeedsLayout()
+        let image = view.asImage()
+        var imageData = image.pngData()
+        
+        let pastboardItems: [String: Any] = ["com.instagram.sharedSticker.stickerImage": imageData]
+        let pastboardOptions = [UIPasteboard.OptionsKey.expirationDate: Date().addingTimeInterval(300)]
+        
+        UIPasteboard.general.setItems([pastboardItems], options: pastboardOptions)
+        
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        } else {
+            guard let instagramURL = URL(string: "https://apps.apple.com/kr/app/instagram/id389801252") else {
+                return
+            }
+            UIApplication.shared.open(instagramURL)
+        }
+    }
 }

--- a/24th-App-Team-1-iOS/Core/Extensions/Sources/UIViewController+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Extensions/Sources/UIViewController+Extensions.swift
@@ -8,7 +8,6 @@
 
 import UIKit
 
-
 public extension UIViewController {
     
     // 뷰 컨트롤러의 뷰에 탭 제스처 인식기를 추가하여, 뷰를 탭하면 키보드를 숨깁니다.
@@ -42,5 +41,15 @@ public extension UIViewController {
             }
             UIApplication.shared.open(instagramURL)
         }
+    }
+    
+    func shareToKakaoTalk() {
+        //TODO: 앱 설치 링크로 변경 및 문구 변경
+        let shareURL = "https://apps.apple.com/kr/app/instagram/id389801252"
+        let shareText = "wespot 설치 링크 입니다."
+        
+        let shareViewController = UIActivityViewController(activityItems: [shareText, shareURL], applicationActivities: nil)
+        shareViewController.excludedActivityTypes = [.copyToPasteboard, .assignToContact]
+        self.present(shareViewController, animated: true)
     }
 }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteCompleteViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteCompleteViewController.swift
@@ -164,6 +164,14 @@ public final class VoteCompleteViewController: BaseViewController<VoteCompleteVi
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        shareButton.rx
+            .tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.shareToInstagramStory(to: owner.completeCollectionView)
+            }
+            .disposed(by: disposeBag)
+        
         reactor.state
             .map { $0.isLoading }
             .distinctUntilChanged()

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteCompleteViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteCompleteViewController.swift
@@ -164,8 +164,16 @@ public final class VoteCompleteViewController: BaseViewController<VoteCompleteVi
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        shareButton.rx
-            .tap
+        noticeButton
+            .rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.shareToKakaoTalk()
+            }
+            .disposed(by: disposeBag)
+        
+        shareButton
+            .rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind(with: self) { owner, _ in
                 owner.shareToInstagramStory(to: owner.completeCollectionView)

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteEffectViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteEffectViewController.swift
@@ -164,6 +164,14 @@ public final class VoteEffectViewController: BaseViewController<VoteEffectViewRe
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        shareButton
+            .rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.shareToInstagramStory(to: owner.effectCollectionView)
+            }
+            .disposed(by: disposeBag)
+        
         reactor.state
             .map { $0.toggleType }
             .distinctUntilChanged()

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteEffectViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteEffectViewController.swift
@@ -164,6 +164,14 @@ public final class VoteEffectViewController: BaseViewController<VoteEffectViewRe
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        noticeButton
+            .rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.shareToKakaoTalk()
+            }
+            .disposed(by: disposeBag)
+        
         shareButton
             .rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteHomeViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteHomeViewController.swift
@@ -120,5 +120,13 @@ public final class VoteHomeViewController: BaseViewController<VoteHomeViewReacto
             .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        voteBannerView
+            .rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.shareToKakaoTalk()
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
@@ -38,7 +38,8 @@ extension InfoPlist {
             "LSApplicationQueriesSchemes": [
                 "kakaokompassauth",
                 "kakaolink",
-                "kakaoplus"
+                "kakaoplus",
+                "instagram-stories"
             ],
             "KAKAO_NATIVE_APP_KEY": .string("${KAKAO_NATIVE_APP_KEY}"),
             "CFBundleURLTypes": .array([


### PR DESCRIPTION
## 작업 내용

- [x] `UIViewController+Extensions` 내부에 카카오톡 공유하기 및 인스타 그램 공유하기 메서드 추가했습니다.
- [x] 카카오톡 공유하기 메서드에서 문구와 이미지 같은 경우는 임시 입니다. 추후에 정해지면 수정 할거라 이점 참고 해주시면 감사하겠습니다.


## 화면 (Optional)
| 인스타 그램 스토리 공유 | 카카오톡 공유 |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/c0d219d7-d941-430b-b74a-1abd0938369a" width="200"/> | <img src="https://github.com/user-attachments/assets/d1309dc7-9471-4f8c-8b77-0a291dcc4bc0" width="200"/> |


<br/><br/><br/>
## 고민점 및 해결 방법 (Optional)
- 카카오톡 공유 같은 경우 `UIActivityviewController`를 사용해서 공유를 했는데 카카오톡 외에 공유 할 수 있다는게 너무 한정적이지 않다는게 문제점이 긴 하네요 근다 문서를 찾아보니깐 OS에서 지원하는 건 UIActivityviewController 방법 외에는 없어서 이걸 사용하긴 했습니다.


<br/><br/><br/>
close: #103 
