### PR TITLE
feat: KeyChain Swift 도입

### DIFF
--- a/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
+++ b/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
@@ -23,6 +23,7 @@ import ReactorKit
 import RxKakaoSDKAuth
 import KakaoSDKAuth
 import MessageFeature
+import KeychainSwift
 
 public class SceneDelegate: UIResponder, UISceneDelegate {
     
@@ -65,7 +66,9 @@ public class SceneDelegate: UIResponder, UISceneDelegate {
         window = UIWindow(windowScene: scene)
         NotificationCenter.default.addObserver(self, selector: #selector(handleUserDidLogin), name: .userDidLogin, object: nil)
         
-        if !(UserDefaultsManager.shared.accessToken?.isEmpty ?? true) { // accessToken 값이 없으면 (회원가입 안됨)
+        let accessToken = KeychainManager.shared.get(type: .accessToken) 
+        
+        if accessToken?.isEmpty ?? true { // accessToken 값이 없으면 (회원가입 안됨)
             let signInViewController = DependencyContainer.shared.injector.resolve(SignInViewController.self)
             window?.rootViewController = UINavigationController(rootViewController: signInViewController)
             

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/Keychain/KeychainManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/Keychain/KeychainManager.swift
@@ -1,0 +1,44 @@
+//
+//  KeychainManager.swift
+//  Storage
+//
+//  Created by eunseou on 8/17/24.
+//
+
+import Foundation
+
+import KeychainSwift
+
+public class KeychainManager {
+    
+    public static let shared = KeychainManager()
+    public let keychain = KeychainSwift()
+    
+    // 저장할 데이터
+    public enum keychainType: String {
+        case accessToken
+        case refreshToken
+    }
+    
+    private init() {}
+    
+    // 데이터 저장하기
+    public func set(value: String, type: keychainType) -> Bool {
+        return keychain.set(value, forKey: type.rawValue)
+    }
+    
+    // 데이터 불러오기
+    public func get(type: keychainType) -> String? {
+        return keychain.get(type.rawValue)
+    }
+    
+    // 데이터 삭제
+    public func delete(type: keychainType) -> Bool {
+        return keychain.delete(type.rawValue)
+    }
+    
+    // 모든 데이터 삭제
+    public func allClear() -> Bool {
+        return keychain.clear()
+    }
+}

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignInViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignInViewReactor.swift
@@ -19,6 +19,7 @@ public final class SignInViewReactor: Reactor {
     
     private let createNewMemberUseCase: CreateNewMemberUseCaseProtocol
     private let createExistingUseCase: CreateExistingMemberUseCaseProtocol
+    private let keychain = KeychainSwift()
     public var initialState: State
     
     public struct State {
@@ -99,7 +100,9 @@ public final class SignInViewReactor: Reactor {
                                             identityToken: identityToken,
                                             fcmToken: fcmToken)
         
-        if (UserDefaultsManager.shared.accessToken?.isEmpty ?? true) {
+        let accessToken = KeychainManager.shared.get(type: .accessToken)
+        
+        if (accessToken?.isEmpty ?? true) {
             return createNewMemberUseCase
                 .execute(body: body)
                 .asObservable()

--- a/24th-App-Team-1-iOS/Shared/ThirdPartyLib/Project.swift
+++ b/24th-App-Team-1-iOS/Shared/ThirdPartyLib/Project.swift
@@ -28,7 +28,8 @@ let project = Project
                 .SPM.rxKakaoSDKAuth,
                 .SPM.kakaoSDKUser,
                 .SPM.rxKakaoSDKUser,
-                .SPM.lottie
+                .SPM.lottie,
+                .SPM.keychain
             ])
         ]
     )

--- a/24th-App-Team-1-iOS/Tuist/Package.resolved
+++ b/24th-App-Team-1-iOS/Tuist/Package.resolved
@@ -109,6 +109,15 @@
       }
     },
     {
+      "identity" : "keychain-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/evgenyneu/keychain-swift",
+      "state" : {
+        "revision" : "5e1b02b6a9dac2a759a1d5dbc175c86bd192a608",
+        "version" : "24.0.0"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",

--- a/24th-App-Team-1-iOS/Tuist/Package.swift
+++ b/24th-App-Team-1-iOS/Tuist/Package.swift
@@ -10,7 +10,8 @@ import PackageDescription
         // Default is .staticFramework
         // productTypes: ["Alamofire": .framework,] 
         productTypes: [
-            "Lottie"  : .framework
+            "Lottie"  : .framework,
+            "Kingfisher" : .framework
         ],
         baseSettings: .settings(configurations: [
             .debug(name: .configuration("DEV")),
@@ -33,6 +34,7 @@ let package = Package(
         .package(url: "https://github.com/kakao/kakao-ios-sdk-rx", branch: "master"),
         .package(url: "https://github.com/airbnb/lottie-ios", from: "4.5.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.24.0"),
-        .package(url: "https://github.com/onevcat/Kingfisher", from: "7.12.0")
+        .package(url: "https://github.com/onevcat/Kingfisher", from: "7.12.0"),
+        .package(url: "https://github.com/evgenyneu/keychain-swift", from: "24.0.0")
     ]
 )

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/TargetDependency+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/TargetDependency+Templates.swift
@@ -71,4 +71,7 @@ extension TargetDependency.SPM {
     
     //MARK: Cache
     public static let kingfisher: TargetDependency = .external(name: "Kingfisher")
+    
+    //MARK: KeyChain
+    public static let keychain: TargetDependency = .external(name: "KeychainSwift")
 }


### PR DESCRIPTION
## 작업 내용

- [x] Keychain-swift 라이브러리 추가
- [x] Keychain swift Manager 추가

<br/>

## 고민점 및 해결 방법 
기존에 사용하던 UserDefaults에 저장해두었던 AccessToken 등의 민감한 정보들을 Keychain을 통해 다룹니다.
UserDefaultsManager의 사용과 유사하게 Storage Module에 KeychainManager.swift File을 추가했습니다.
SceneDeleagate에서 UserDefaultsManager를 통해 불러오던 AccessToken값을 KeycainManager로 대체했습니다.


<br/>

## 레퍼런스 
[keychain-swift official document](https://github.com/evgenyneu/keychain-swift)


<br/>

close: #116 
