### PR TITLE
fix: 카카오 로그인 AuthController 전환 이슈 수정

### DIFF
--- a/24th-App-Team-1-iOS/App/Sources/Applications/AppDelegate.swift
+++ b/24th-App-Team-1-iOS/App/Sources/Applications/AppDelegate.swift
@@ -28,6 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         //MARK: Firebase
         FirebaseApp.configure()
+        Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self
         
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound] // 필요한 알림 권한을 설정
@@ -42,7 +43,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
         
         application.registerForRemoteNotifications()
-        Messaging.messaging().delegate = self
         return true
     }
 }
@@ -57,7 +57,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     
     // Foreground 상태에서도 알림 O
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.list, .banner])
+        completionHandler([.banner, .badge, .sound])
     }
 }
 

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VoteInventoryDetailPresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VoteInventoryDetailPresentationAssembly.swift
@@ -14,17 +14,18 @@ import Swinject
 struct VoteInventoryDetailPresentationAssembly: Assembly {
     
     func assemble(container: Container) {
-        container.register(VoteInventoryDetailViewReactor.self) { (resolver, voteId: Int) in
+        container.register(VoteInventoryDetailViewReactor.self) { (resolver, voteId: Int, voteDate: String) in
             let fetchIndividualUseCase = resolver.resolve(FetchIndividualItemUseCaseProtocol.self)!
             
             return VoteInventoryDetailViewReactor(
                 fetchIndividualItemUseCase: fetchIndividualUseCase,
-                voteId: voteId
+                voteId: voteId,
+                voteDate: voteDate
             )
         }
         
-        container.register(VoteInventoryDetailViewController.self) { (resolver, voteId: Int) in
-            let reactor = resolver.resolve(VoteInventoryDetailViewReactor.self, argument: voteId)!
+        container.register(VoteInventoryDetailViewController.self) { (resolver, voteId: Int, voteDate: String) in
+            let reactor = resolver.resolve(VoteInventoryDetailViewReactor.self, arguments: voteId, voteDate)!
             
             return VoteInventoryDetailViewController(reactor: reactor)
         }

--- a/24th-App-Team-1-iOS/Core/Extensions/Sources/UIViewController+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Extensions/Sources/UIViewController+Extensions.swift
@@ -22,17 +22,17 @@ public extension UIViewController {
     }
     
     func shareToInstagramStory(to view: UIView) {
-        guard let url = URL(string: "itms-apps://itunes.apple.com/app/"+"6661029016") else { return }
-        
+        guard let url = URL(string: "instagram-stories://share?source_application="+"123444") else { return }
+
         view.setNeedsLayout()
         let image = view.asImage()
         var imageData = image.pngData()
-        
+
         let pastboardItems: [String: Any] = ["com.instagram.sharedSticker.stickerImage": imageData]
         let pastboardOptions = [UIPasteboard.OptionsKey.expirationDate: Date().addingTimeInterval(300)]
-        
+
         UIPasteboard.general.setItems([pastboardItems], options: pastboardOptions)
-        
+
         if UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)
         } else {
@@ -44,7 +44,7 @@ public extension UIViewController {
     }
     
     func shareToKakaoTalk() {
-        let shareURL = URL(string: "itms-apps://itunes.apple.com/app/"+"6661029016")!
+        let shareURL = URL(string: "https://apps.apple.com/kr/app/instagram/id6661029016")!
         
         
         let shareViewController = UIActivityViewController(activityItems: [WSURLItemSource(wespotAppURL: shareURL)], applicationActivities: nil)

--- a/24th-App-Team-1-iOS/Core/Util/Sources/URLTyps/WSURLType.swift
+++ b/24th-App-Team-1-iOS/Core/Util/Sources/URLTyps/WSURLType.swift
@@ -35,6 +35,8 @@ public enum WSURLType {
     case privacyTerms
     /// 마케팅 정보 수신 이용 약관
     case marketingTerms
+    /// 결제 렌딩 링크
+    case payment
     
     
     public var urlString: URL {
@@ -65,6 +67,8 @@ public enum WSURLType {
             return URL(string: "https://www.notion.so/2fa1c3002e14460f91462204b0daefbf")!
         case .marketingTerms:
             return URL(string: "https://www.notion.so/b14afbb4f9194b5881fd198c8538aba8")!
+        case .payment:
+            return URL(string: "https://payforresult.imweb.me/")!
         }
     }
 }

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/PolicyAgreementBottomSheetViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/PolicyAgreementBottomSheetViewController.swift
@@ -24,7 +24,7 @@ public final class PolicyAgreementBottomSheetViewController: BaseViewController<
     private let allAggreementButton = SelectPolicyAgreementView(text: "전체 동의하기", font: .Body04, isHiddenDetailButton: true)
     private let serviceAgreementButton = SelectPolicyAgreementView(text: "(필수) 서비스 이용약관")
     private let privacyAgreementButton = SelectPolicyAgreementView(text: "(필수) 개인정보 수집 및 이용 안내")
-    public let marketingAgreementButton = SelectPolicyAgreementView(text: "(선택) 이벤트 및 마케팇 수신 동의")
+    public let marketingAgreementButton = SelectPolicyAgreementView(text: "(선택) 이벤트 및 마케팅 수신 동의")
     
     
     public override func viewDidLoad() {

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/SignUpGenderViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/SignUpGenderViewController.swift
@@ -51,16 +51,15 @@ public final class SignUpGenderViewController: BaseViewController<SignUpGenderVi
         }
         boyCardButton.snp.makeConstraints {
             $0.top.equalTo(subTitleLabel.snp.bottom).offset(16)
-            $0.leading.greaterThanOrEqualTo(view.safeAreaLayoutGuide).offset(26)
-            $0.width.equalTo(152)
+            $0.left.equalTo(view.safeAreaLayoutGuide).inset(26)
             $0.height.equalTo(180)
         }
         girlCardButton.snp.makeConstraints {
             $0.top.equalTo(subTitleLabel.snp.bottom).offset(16)
-            $0.leading.equalTo(boyCardButton.snp.trailing).offset(20)
-            $0.trailing.greaterThanOrEqualTo(view.safeAreaLayoutGuide).inset(26)
-            $0.width.equalTo(152)
+            $0.left.equalTo(boyCardButton.snp.right).offset(20)
+            $0.right.equalTo(view.safeAreaLayoutGuide).inset(26)
             $0.height.equalTo(180)
+            $0.width.equalTo(boyCardButton)
         }
     }
     

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/SignUpInfoBottomSheetViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/SignUpInfoBottomSheetViewController.swift
@@ -82,15 +82,14 @@ public final class SignUpInfoBottomSheetViewController: BaseViewController<SignU
         }
         editButton.snp.makeConstraints {
             $0.top.equalTo(profileImageView.snp.bottom).offset(39.5)
-            $0.leading.equalToSuperview().offset(20)
+            $0.leading.equalToSuperview().inset(20)
             $0.height.equalTo(52)
-            $0.width.greaterThanOrEqualTo(162)
         }
         confirmButton.snp.makeConstraints {
             $0.top.equalTo(profileImageView.snp.bottom).offset(39.5)
             $0.leading.equalTo(editButton.snp.trailing).offset(11)
             $0.height.equalTo(52)
-            $0.width.greaterThanOrEqualTo(162)
+            $0.width.equalTo(editButton)
             $0.trailing.equalToSuperview().inset(20)
         }
     }
@@ -115,7 +114,7 @@ public final class SignUpInfoBottomSheetViewController: BaseViewController<SignU
         }
         
         profileImageView.do {
-            $0.image = DesignSystemAsset.Images.profile.image
+            $0.image = DesignSystemAsset.Images.icDefaultProfile.image
         }
         
         titleLabel.do {

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteInventoryDetailViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteInventoryDetailViewReactor.swift
@@ -19,6 +19,7 @@ public final class VoteInventoryDetailViewReactor: Reactor {
         @Pulse var receiveEntity: VoteIndividualEntity?
         @Pulse var isLoading: Bool
         var voteId: Int
+        var voteDate: String
     }
     
     public enum Action {
@@ -32,12 +33,14 @@ public final class VoteInventoryDetailViewReactor: Reactor {
     
     public init(
         fetchIndividualItemUseCase: FetchIndividualItemUseCaseProtocol,
-        voteId: Int
+        voteId: Int,
+        voteDate: String
     ) {
         self.initialState = State(
             receiveEntity: nil,
             isLoading: false,
-            voteId: voteId
+            voteId: voteId,
+            voteDate: voteDate
         )
         self.fetchIndividualItemUseCase = fetchIndividualItemUseCase
     }
@@ -47,7 +50,7 @@ public final class VoteInventoryDetailViewReactor: Reactor {
         
         switch action {
         case .viewDidLoad:
-            let query = VoteIndividualQuery(date: Date().toFormatString(with: .dashYyyyMMdd))
+            let query = VoteIndividualQuery(date: currentState.voteDate)
             return fetchIndividualItemUseCase
                 .execute(id: currentState.voteId, query: query)
                 .asObservable()

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteInventoryDetailViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteInventoryDetailViewController.swift
@@ -136,7 +136,7 @@ public final class VoteInventoryDetailViewController: BaseViewController<VoteInv
         
         detailBackgroundImageView.do {
             $0.image = DesignSystemAsset.Images.bgResultGradation.image
-            $0.contentMode = .scaleAspectFill
+            $0.contentMode = .scaleToFill
         }
         
         detailContainerView.do {
@@ -193,9 +193,18 @@ public final class VoteInventoryDetailViewController: BaseViewController<VoteInv
         
         detailConfirmButton
             .rx.tap
-            .throttle(.microseconds(300), scheduler: MainScheduler.instance)
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind(with: self) { owner, _ in
-                owner.shareToKakaoTalk()
+                let paymentWebViewController = DependencyContainer.shared.injector.resolve(WSWebViewController.self, argument: WSURLType.payment.urlString)
+                owner.navigationController?.pushViewController(paymentWebViewController, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        detailSharedButton
+            .rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.shareToInstagramStory(to: owner.view)
             }
             .disposed(by: disposeBag)
         

--- a/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/WebView/WSWebViewController.swift
+++ b/24th-App-Team-1-iOS/Shared/DesignSystem/Sources/Components/WebView/WSWebViewController.swift
@@ -71,5 +71,12 @@ public final class WSWebViewController: UIViewController, ReactorKit.View {
             .distinctUntilChanged()
             .bind(to: webView.rx.loadURL)
             .disposed(by: disposeBag)
+        
+        navigationBar.leftBarButton
+            .rx.tap
+            .bind(with: self) { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION

## 작업 내용
- [x] 카카오 로그인 AuthController 이슈 수정
- [x] WSURLType 결제 랜딩페이지 URL 추가
- [x] 이벤트 약관 동의 오타 수정
- [x] instagram Share 로직 수정
- [x] 회원 가입 UI AutoLayout 수정
- [x] 투표 보관함 상세 결제 렌딩페이지 로직 추가
- [x] WebViewController 뒤로가기 버튼 로직 추가
- [x] `보낸 투표`, `받은 투표`  페이지네이션 이슈 수정
- [x] 투표 보관함 상세 화면 무한 로딩 이슈 수정



<br/><br/><br/>
close: #145 
