### PR TITLE
fix: 투표 진행 화면에서 투표 진행 횟수 이슈를 수정해요

### DIFF
--- a/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
+++ b/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
@@ -11,6 +11,7 @@ import Storage
 import DesignSystem
 
 import LoginFeature
+import CommonDomain
 import LoginDomain
 import LoginService
 import VoteFeature
@@ -134,9 +135,15 @@ extension SceneDelegate {
             topViewController.navigationController?.pushViewController(notificationViewController, animated: true)
         }
         
-        NotificationCenter.default.addObserver(forName: .showVoteProccessController, object: nil, queue: .main) { _ in
-            let voteProcessViewController = DependencyContainer.shared.injector.resolve(VoteProcessViewController.self)
-            topViewController.navigationController?.pushViewController(voteProcessViewController, animated: true)
+        NotificationCenter.default.addObserver(forName: .showVoteProccessController, object: nil, queue: .main) { notification in
+            let voteOption = notification.userInfo?["voteOption"] as? VoteResponseEntity
+            if !(voteOption?.response.isEmpty ?? true) {
+                let voteProcessViewController = DependencyContainer.shared.injector.resolve(VoteProcessViewController.self, argument: voteOption)
+                topViewController.navigationController?.pushViewController(voteProcessViewController, animated: true)
+            } else {
+                let voteBeginViewController = DependencyContainer.shared.injector.resolve(VoteBeginViewController.self)
+                topViewController.navigationController?.pushViewController(voteBeginViewController, animated: true)
+            }
         }
         
         NotificationCenter.default.addObserver(forName: .showVoteInventoryViewController, object: nil, queue: .main) { _ in

--- a/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
+++ b/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
@@ -73,8 +73,10 @@ public class SceneDelegate: UIResponder, UISceneDelegate {
         window = UIWindow(windowScene: scene)
         
         let accessToken = KeychainManager.shared.get(type: .accessToken)
+        let refreshToken = KeychainManager.shared.get(type: .refreshToken)
         
-        if accessToken == nil { // accessToken 값이 없으면 (회원가입 안됨)
+        
+        if accessToken == nil || refreshToken == nil { // accessToken 값이 없으면 (회원가입 안됨)
             let signInViewController = DependencyContainer.shared.injector.resolve(SignInViewController.self)
             window?.rootViewController = UINavigationController(rootViewController: signInViewController)
             

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/DoaminDI/DomainAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/DoaminDI/DomainAssembly.swift
@@ -116,8 +116,8 @@ struct DomainAssembly: Assembly {
         
         // Profile
         container.register(FetchUserProfileUseCaseProtocol.self) { resolver in
-            let repository = resolver.resolve(ProfileRepositoryProtocol.self)!
-            return FetchUserProfileUseCase(profileRepository: repository)
+            let repository = resolver.resolve(CommonRepositoryProtocol.self)!
+            return FetchUserProfileUseCase(commonRepository: repository)
         }
         
         container.register(UpdateUserProfileUseCaseProtocol.self) { resolver in

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/DoaminDI/DomainAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/DoaminDI/DomainAssembly.swift
@@ -63,8 +63,8 @@ struct DomainAssembly: Assembly {
         }
         
         container.register(FetchVoteOptionsUseCaseProtocol.self) { resolver in
-            let repository = resolver.resolve(VoteRepositoryProtocol.self)!
-            return FetchVoteOptionsUseCase(voteRepository: repository)
+            let repository = resolver.resolve(CommonRepositoryProtocol.self)!
+            return FetchVoteOptionsUseCase(commonRepository: repository)
         }
         
         container.register(CreateVoteUseCaseProtocol.self) { resolver in

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/All/AllMainPresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/All/AllMainPresentationAssembly.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import AllFeature
-import AllDomain
+import CommonDomain
 
 import Swinject
 

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Notification/NotificationPresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Notification/NotificationPresentationAssembly.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NotificationFeature
+import CommonDomain
 import NotificationDomain
 
 import Swinject
@@ -18,9 +19,11 @@ struct NotificationPresentationAssembly: Assembly {
         container.register(NotificationViewReactor.self) { resolver in
             let fetchUserNotificationItemUseCase = resolver.resolve(FetchUserNotificationItemUseCaseProtocol.self)!
             let updateUserNotificationItemUseCase = resolver.resolve(UpdateUserNotificationItemUseCaseProtocol.self)!
+            let fetchVoteOptionUseCase = resolver.resolve(FetchVoteOptionsUseCaseProtocol.self)!
             return NotificationViewReactor(
                 fetchUserNotificationItemsUseCase: fetchUserNotificationItemUseCase,
-                updateUserNotifcationItemUseCase: updateUserNotificationItemUseCase
+                updateUserNotifcationItemUseCase: updateUserNotificationItemUseCase,
+                fetchVoteOptionUseCase: fetchVoteOptionUseCase
             )
         }
         

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VoteMainPresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VoteMainPresentationAssembly.swift
@@ -8,6 +8,7 @@
 import Foundation
 import VoteFeature
 import VoteDomain
+import CommonDomain
 
 import Swinject
 
@@ -42,7 +43,8 @@ struct VoteMainPresentationAssembly: Assembly {
 struct VoteHomePresentationAssembly: Assembly {
     func assemble(container: Container) {
         container.register(VoteHomeViewReactor.self) { resolver in
-            return VoteHomeViewReactor()
+            let fetchVoteOptionsUseCase = resolver.resolve(FetchVoteOptionsUseCaseProtocol.self)!
+            return VoteHomeViewReactor(fetchVoteOptionUseCase: fetchVoteOptionsUseCase)
         }
         
         container.register(VoteHomeViewController.self) { resovler in

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VotePresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VotePresentationAssembly.swift
@@ -49,8 +49,9 @@ struct VotePresentationAssembly: Assembly {
             return VoteProcessViewController(reactor: reactor)
         }
         
-        container.register(VoteBeginViewReactor.self) { _ in
-            return VoteBeginViewReactor()
+        container.register(VoteBeginViewReactor.self) { resolver in
+            let fetchUserProfileUseCase = resolver.resolve(FetchUserProfileUseCaseProtocol.self)!
+            return VoteBeginViewReactor(fetchUserProfileUseCase: fetchUserProfileUseCase)
         }
         
         container.register(VoteBeginViewController.self) { resolver in

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VotePresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VotePresentationAssembly.swift
@@ -50,5 +50,15 @@ struct VotePresentationAssembly: Assembly {
             
             return VoteProcessViewController(reactor: reactor)
         }
+        
+        container.register(VoteBeginViewReactor.self) { _ in
+            return VoteBeginViewReactor()
+        }
+        
+        container.register(VoteBeginViewController.self) { resolver in
+            let reactor = resolver.resolve(VoteBeginViewReactor.self)!
+            
+            return VoteBeginViewController(reactor: reactor)
+        }
     }
 }

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VotePresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VotePresentationAssembly.swift
@@ -15,7 +15,7 @@ import Swinject
 
 struct VotePresentationAssembly: Assembly {
     func assemble(container: Container) {
-        container.register(VoteProcessViewReactor.self) { (resolver, voteResponseEntity: VoteResponseEntity?, voteOptionStub: [CreateVoteItemReqeuest], processCount: Int) in
+        container.register(VoteProcessViewReactor.self) { (resolver, voteResponseEntity: VoteResponseEntity?) in
             let createVoteUseCase = resolver.resolve(CreateVoteUseCaseProtocol.self)!
             let createUserReportUseCase = resolver.resolve(CreateReportUserUseCaseProtocol.self)!
             let fetchVoteOptionsUseCase = resolver.resolve(FetchVoteOptionsUseCaseProtocol.self)!
@@ -23,9 +23,7 @@ struct VotePresentationAssembly: Assembly {
                 createVoteUseCase: createVoteUseCase,
                 createUserReportUseCase: createUserReportUseCase,
                 fetchVoteOptionsUseCase: fetchVoteOptionsUseCase,
-                voteResponseEntity: voteResponseEntity,
-                voteOptionStub: voteOptionStub,
-                processCount: processCount
+                voteResponseEntity: voteResponseEntity
             )
         }
         
@@ -41,8 +39,8 @@ struct VotePresentationAssembly: Assembly {
             )
         }
         
-        container.register(VoteProcessViewController.self) { (resolver, voteResponseEntity: VoteResponseEntity?, voteOptionStub: [CreateVoteItemReqeuest], processCount: Int) in
-            let reactor = resolver.resolve(VoteProcessViewReactor.self, arguments: voteResponseEntity, voteOptionStub, processCount)!
+        container.register(VoteProcessViewController.self) { (resolver, voteResponseEntity: VoteResponseEntity?) in
+            let reactor = resolver.resolve(VoteProcessViewReactor.self, argument: voteResponseEntity)!
             
             return VoteProcessViewController(reactor: reactor)
         }

--- a/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VotePresentationAssembly.swift
+++ b/24th-App-Team-1-iOS/App/Sources/DIContainer/PresentationDI/Vote/VotePresentationAssembly.swift
@@ -22,7 +22,6 @@ struct VotePresentationAssembly: Assembly {
             return VoteProcessViewReactor(
                 createVoteUseCase: createVoteUseCase,
                 createUserReportUseCase: createUserReportUseCase,
-                fetchVoteOptionsUseCase: fetchVoteOptionsUseCase,
                 voteResponseEntity: voteResponseEntity
             )
         }
@@ -34,8 +33,7 @@ struct VotePresentationAssembly: Assembly {
             
             return VoteProcessViewReactor(
                 createVoteUseCase: createVoteUseCase,
-                createUserReportUseCase: createUserReportUseCase,
-                fetchVoteOptionsUseCase: fetchVoteOptionsUseCase
+                createUserReportUseCase: createUserReportUseCase
             )
         }
         

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/MonitorImpl/WSNetworkMonitor.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/MonitorImpl/WSNetworkMonitor.swift
@@ -25,7 +25,7 @@ public final class WSNetworkMonitor: EventMonitor {
     }
     
     
-    public func request(_ request: DataRequest, didParseResponse response: DataResponse<Data?, AFError>) {
+    public func request<Value>(_ request: DataRequest, didParseResponse response: DataResponse<Value, AFError>) {
         WSLogger.debug(category: Network.default, message: "✅Response WSNetwork LOG✅")
         WSLogger.debug(category: Network.default, message: "URL : \((request.request?.url?.absoluteString ?? ""))")
         WSLogger.debug(category: Network.default, message: "Results : \((response.result))")

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/CommonEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/CommonEndPoint.swift
@@ -18,6 +18,7 @@ public enum CommonEndPoint: WSNetworkEndPoint {
         return accessToken
     }
     
+    case fetchUserProfile
     // 비속어 검색 API
     case createProfanityCheck(Encodable)
     // 프로필 캐릭터 정보 API
@@ -33,6 +34,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
     
     public var path: String {
         switch self {
+        case .fetchUserProfile:
+            return "/users/me"
         case .createProfanityCheck:
             return "/check-profanity"
         case .fetchCharacters:
@@ -50,6 +53,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
     
     public var method: HTTPMethod {
         switch self {
+        case .fetchUserProfile:
+            return .get
         case .createProfanityCheck:
             return .post
         case .fetchCharacters:

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/CommonEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/CommonEndPoint.swift
@@ -28,6 +28,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
     case createUserReport(Encodable)
     /// 사용자 프로필 수정 API
     case updateUserProfile(Encodable)
+    /// 질문지 조회 API
+    case fetchVoteOptions
     
     public var path: String {
         switch self {
@@ -41,6 +43,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
             return "/reports"
         case .updateUserProfile:
             return "/users/me"
+        case .fetchVoteOptions:
+            return "votes/options"
         }
     }
     
@@ -56,6 +60,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
             return .post
         case .updateUserProfile:
             return .put
+        case .fetchVoteOptions:
+            return .get
         }
     }
     
@@ -71,6 +77,8 @@ public enum CommonEndPoint: WSNetworkEndPoint {
             return .requestBody(body)
         case let .updateUserProfile(body):
             return .requestBody(body)
+        default:
+            return .none
         }
     }
     

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/NotificationEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/NotificationEndPoint.swift
@@ -38,7 +38,7 @@ public enum NotificationEndPoint: WSNetworkEndPoint {
         case .fetchNotificationItems:
             return .get
         case .updateNotification:
-            return .put
+            return .patch
         }
     }
     

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/VoteEndPoint.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/EndPointImpl/VoteEndPoint.swift
@@ -21,8 +21,6 @@ public enum VoteEndPoint: WSNetworkEndPoint {
     
     /// 반 친구 조회 API
     case fetchClassMates
-    /// 질문지 조회 API
-    case fetchVoteOptions
     /// 투표 하기 API
     case addVotes(Encodable)
     /// 투표 결과 전체 조회하기
@@ -40,8 +38,6 @@ public enum VoteEndPoint: WSNetworkEndPoint {
         switch self {
         case .fetchClassMates:
             return "/users/classmates"
-        case .fetchVoteOptions:
-            return "/votes/options"
         case .addVotes:
             return "/votes"
         case .fetchResultVotes:
@@ -60,8 +56,6 @@ public enum VoteEndPoint: WSNetworkEndPoint {
     public var method: HTTPMethod {
         switch self {
         case .fetchClassMates:
-            return .get
-        case .fetchVoteOptions:
             return .get
         case .addVotes:
             return .post

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkInterceptor.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkInterceptor.swift
@@ -14,11 +14,11 @@ import RxSwift
 import RxCocoa
 
 public final class WSNetworkInterceptor: RequestInterceptor {
-
+    
     private var retryLimit = 2
     private let disposeBag = DisposeBag()
     
-    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, any Error>) -> Void) {
+    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         var urlRequest = urlRequest
         
         guard let accessToken = KeychainManager.shared.get(type: .accessToken) else {
@@ -33,35 +33,34 @@ public final class WSNetworkInterceptor: RequestInterceptor {
     
     public func retry(_ request: Request, for session: Session, dueTo error: any Error, completion: @escaping (RetryResult) -> Void) {
         
-        let refreshToken = KeychainManager.shared.get(type: .refreshToken)
-        
-        guard let statusCode = request.response?.statusCode,
-              request.retryCount < retryLimit else { return completion(.doNotRetry) }
-        
-        if request.retryCount < retryLimit {
-            if statusCode == 401  {
-                guard let refreshToken = KeychainManager.shared.get(type: .refreshToken) else { 
-                    return completion(.doNotRetryWithError(WSNetworkError.default(message: "리프레쉬 토큰을 찾을 수 없습니다.")))
-                }
-                
-                let body = ReissueToken(token: refreshToken)
-                let endPoint = ReissueEndPoint.createReissueToken(body: body)
-                WSNetworkService().request(endPoint: endPoint)
-                    .asObservable()
-                    .decodeMap(AccessToken.self)
-                    .logErrorIfDetected(category: Network.error)
-                    .subscribe { token in
-                        KeychainManager.shared.set(value: token.accessToken, type: .accessToken)
-                        KeychainManager.shared.set(value: token.refreshToken, type: .refreshToken)
-                    } onError: { error in
-                        completion(.doNotRetryWithError(error))
-                    }
-                    .disposed(by: disposeBag)
-
-
-
-                
-            }
+        guard let response = request.task?.response as? HTTPURLResponse else {
+            completion(.doNotRetryWithError(error))
+            return
         }
+        
+        
+        guard response.statusCode == 401 else {
+            completion(.doNotRetry)
+            return
+        }
+        
+        guard let refreshToken = KeychainManager.shared.get(type: .refreshToken) else {
+            return completion(.doNotRetryWithError(WSNetworkError.default(message: "리프레쉬 토큰을 찾을 수 없습니다.")))
+        }
+        
+        let body = ReissueToken(token: refreshToken)
+        let endPoint = ReissueEndPoint.createReissueToken(body: body)
+        WSNetworkService().request(endPoint: endPoint)
+            .asObservable()
+            .decodeMap(AccessToken.self)
+            .logErrorIfDetected(category: Network.error)
+            .subscribe { token in
+                KeychainManager.shared.set(value: token.accessToken, type: .accessToken)
+                KeychainManager.shared.set(value: token.refreshToken, type: .refreshToken)
+            } onError: { error in
+                completion(.doNotRetryWithError(error))
+            }
+            .disposed(by: disposeBag)
+        
     }
 }

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkService.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkService.swift
@@ -17,7 +17,7 @@ public final class WSNetworkService: WSNetworkServiceProtocol {
         let networkMonitor: WSNetworkMonitor = WSNetworkMonitor()
         let networkConfigure: URLSessionConfiguration = URLSessionConfiguration.af.default
         let interceptor = WSNetworkInterceptor()
-               
+        networkConfigure.timeoutIntervalForRequest = 60
         let networkSession: Session = Session(
             configuration: networkConfigure,
             interceptor: interceptor,

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkService.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkService.swift
@@ -9,7 +9,6 @@ import Foundation
 
 import Alamofire
 import RxSwift
-import CommonDomain
 
 public final class WSNetworkService: WSNetworkServiceProtocol {
     

--- a/24th-App-Team-1-iOS/Core/Storage/Project.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Project.swift
@@ -14,7 +14,8 @@ let project = Project
         targets: [
             .core(module: .Storage, dependencies: [
                 .shared(module: .ThirdPartyLib),
-                .domain(module: .LoginDomain)
+                .domain(module: .LoginDomain),
+                .domain(module: .VoteDomain)
             ])
         ]
     )

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaults/UserDefaultsManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaults/UserDefaultsManager.swift
@@ -21,8 +21,6 @@ public class UserDefaultsManager {
         case refreshToken // 재발행 토큰
         case userName // 사용자 이름
         case socialType // 사용자 로그인 타입
-        case grade
-        case classNumber
         case userProfileImage
         case userBackgroundColor
         case fcmToken
@@ -44,12 +42,6 @@ public class UserDefaultsManager {
     
     @UserDefaultsWrapper(key: Key.socialType.rawValue, defaultValue: "")
         public var socialType: String?
-    
-    @UserDefaultsWrapper(key: Key.grade.rawValue, defaultValue: 0)
-        public var grade: Int?
-    
-    @UserDefaultsWrapper(key: Key.classNumber.rawValue, defaultValue: 0)
-        public var classNumber: Int?
     
     @UserDefaultsWrapper(key: Key.userProfileImage.rawValue, defaultValue: "")
         public var userProfileImage: String?

--- a/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaults/UserDefaultsManager.swift
+++ b/24th-App-Team-1-iOS/Core/Storage/Sources/UserDefaults/UserDefaultsManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import LoginDomain
+import VoteDomain
 
 public class UserDefaultsManager {
     
@@ -25,6 +26,7 @@ public class UserDefaultsManager {
         case userProfileImage
         case userBackgroundColor
         case fcmToken
+        case voteStub
         case expiredDate
     }
     
@@ -55,11 +57,14 @@ public class UserDefaultsManager {
     @UserDefaultsWrapper(key: Key.userBackgroundColor.rawValue, defaultValue: "")
         public var userBackgroundColor: String?
     
-    @UserDefaultsWrapper(key: Key.expiredDate.rawValue, defaultValue: nil)
-        public var expiredDate: Date?
+    @UserDefaultsWrapper(key: Key.expiredDate.rawValue, defaultValue: Date())
+        public var expiredDate: Date
     
     @UserDefaultsWrapper(key: Key.fcmToken.rawValue, defaultValue: "")
         public var fcmToken: String?
+    
+    @UserDefaultsWrapper(key: Key.voteStub.rawValue, defaultValue: [])
+        public var voteRequest: [CreateVoteItemReqeuest]
     
     
     public func clearAllData() {

--- a/24th-App-Team-1-iOS/Core/Util/Sources/GlobalState/WSGlobalStateService.swift
+++ b/24th-App-Team-1-iOS/Core/Util/Sources/GlobalState/WSGlobalStateService.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
-import VoteDomain
+import CommonDomain
 
 import RxSwift
+
 
 
 public protocol WSGlobalServiceProtocol {
@@ -35,7 +36,7 @@ public enum WSGlobalStateType {
     case didChangedAccountSchoolName(schoolName: String)
     case didTappedFriendButton(_ isSelected: Bool)
     case didTappedResultButton
-    case didTappedVoteButton(_ isSelected: Bool)
+    case didTappedVoteButton(_ isSelected: Bool, voteOption: VoteResponseEntity?)
     case toogleMessageType(_ type: MessageTypes)
     case didTappedCharacterItem(_ item: Int)
     case didTappedBackgroundItem(_ item: Int)

--- a/24th-App-Team-1-iOS/Domain/AllDomain/Sources/Repositories/ProfileRepositoryProtocol.swift
+++ b/24th-App-Team-1-iOS/Domain/AllDomain/Sources/Repositories/ProfileRepositoryProtocol.swift
@@ -10,7 +10,6 @@ import Foundation
 import RxSwift
 
 public protocol ProfileRepositoryProtocol {
-    func fetchUserProfileItems() -> Single<UserProfileEntity?>
     func fetchUserAlarmItems() -> Single<UserAlarmEntity?>
     func updateUserAlarmItem(body: UpdateUserProfileAlarmRequest) -> Single<Bool>
     func fetchUserBlockItems(query: UserBlockRequestQuery) -> Single<UserBlockEntity?>

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Entities/UserProfileEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Entities/UserProfileEntity.swift
@@ -1,12 +1,11 @@
 //
 //  UserProfileEntity.swift
-//  AllDomain
+//  CommonDomain
 //
-//  Created by Kim dohyun on 8/12/24.
+//  Created by 김도현 on 10/16/24.
 //
 
 import Foundation
-
 
 public struct UserProfileEntity: Identifiable {
     public let id: Int
@@ -39,7 +38,6 @@ public struct UserProfileEntity: Identifiable {
     }
 }
 
-
 public struct UserProfileResponseEntity {
     public let backgroundColor: String
     public let iconUrl: URL
@@ -49,3 +47,4 @@ public struct UserProfileResponseEntity {
         self.iconUrl = iconUrl
     }
 }
+

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Entities/VoteOptionEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Entities/VoteOptionEntity.swift
@@ -1,8 +1,8 @@
 //
 //  VoteOptionEntity.swift
-//  VoteDomain
+//  CommonDomain
 //
-//  Created by Kim dohyun on 7/22/24.
+//  Created by Kim dohyun on 10/10/24.
 //
 
 import Foundation

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Repositories/CommonRepositoryProtocol.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Repositories/CommonRepositoryProtocol.swift
@@ -10,6 +10,7 @@ import Foundation
 import RxSwift
 
 public protocol CommonRepositoryProtocol {
+    func fetchUserProfileItems() -> Single<UserProfileEntity?>
     func createCheckProfanity(body: CreateCheckProfanityRequest) -> Single<Bool>
     func fetchProfileImages() -> Single<FetchProfileImageResponseEntity?>
     func updateUserProfileItem(body: UpdateUserProfileRequest) -> Single<Bool>

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Repositories/CommonRepositoryProtocol.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/Repositories/CommonRepositoryProtocol.swift
@@ -15,4 +15,5 @@ public protocol CommonRepositoryProtocol {
     func updateUserProfileItem(body: UpdateUserProfileRequest) -> Single<Bool>
     func fetchProfileBackgrounds() -> Single<FetchProfileBackgroundsResponseEntity?>
     func createReportUserItem(body: CreateUserReportRequest) -> Single<CreateReportUserEntity?>
+    func fetchVoteOptions() -> Single<VoteResponseEntity?>
 }

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/UseCases/FetchUserProfileUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/UseCases/FetchUserProfileUseCase.swift
@@ -1,8 +1,8 @@
 //
 //  FetchUserProfileUseCase.swift
-//  AllDomain
+//  CommonDomain
 //
-//  Created by Kim dohyun on 8/12/24.
+//  Created by 김도현 on 10/16/24.
 //
 
 import Foundation
@@ -10,20 +10,22 @@ import Foundation
 import RxSwift
 import RxCocoa
 
+
 public protocol FetchUserProfileUseCaseProtocol {
     func execute() -> Single<UserProfileEntity?>
 }
 
+
 public final class FetchUserProfileUseCase: FetchUserProfileUseCaseProtocol {
     
+    private let commonRepository: CommonRepositoryProtocol
     
-    private let profileRepository: ProfileRepositoryProtocol
-    
-    public init(profileRepository: ProfileRepositoryProtocol) {
-        self.profileRepository = profileRepository
+    public init(commonRepository: CommonRepositoryProtocol) {
+        self.commonRepository = commonRepository
     }
     
+    
     public func execute() -> Single<UserProfileEntity?> {
-        return profileRepository.fetchUserProfileItems()
+        return commonRepository.fetchUserProfileItems()
     }
 }

--- a/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/UseCases/FetchVoteOptionsUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/CommonDomain/Sources/UseCases/FetchVoteOptionsUseCase.swift
@@ -1,8 +1,8 @@
 //
 //  FetchVoteOptionsUseCase.swift
-//  VoteDomain
+//  CommonDomain
 //
-//  Created by Kim dohyun on 7/22/24.
+//  Created by Kim dohyun on 10/10/24.
 //
 
 import Foundation
@@ -16,13 +16,13 @@ public protocol FetchVoteOptionsUseCaseProtocol {
 
 public final class FetchVoteOptionsUseCase: FetchVoteOptionsUseCaseProtocol {
     
-    private let voteRepository: VoteRepositoryProtocol
+    private let commonRepository: CommonRepositoryProtocol
     
-    public init(voteRepository: VoteRepositoryProtocol) {
-        self.voteRepository = voteRepository
+    public init(commonRepository: CommonRepositoryProtocol) {
+        self.commonRepository = commonRepository
     }
     
     public func execute() -> Single<VoteResponseEntity?> {
-        return voteRepository.fetchVoteOptions()
+        return commonRepository.fetchVoteOptions()
     }
 }

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateExistingTokenEntity.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Entities/CreateExistingTokenEntity.swift
@@ -1,0 +1,52 @@
+//
+//  CreateExistingTokenEntity.swift
+//  LoginDomain
+//
+//  Created by 김도현 on 10/16/24.
+//
+
+import Foundation
+
+
+public struct CreateExistingTokenEntity {
+    let isProfileChanged: Bool
+    public let refreshToken: String
+    public let refreshTokenExpiredAt: Date
+    public let accessToken: String
+    let name: String
+    let setting: CreateExistingMemberSettingEntity
+    
+    public init(
+        isProfileChanged: Bool,
+        refreshToken: String,
+        refreshTokenExpiredAt: Date,
+        accessToken: String,
+        name: String,
+        setting: CreateExistingMemberSettingEntity
+    ) {
+        self.isProfileChanged = isProfileChanged
+        self.refreshToken = refreshToken
+        self.refreshTokenExpiredAt = refreshTokenExpiredAt
+        self.accessToken = accessToken
+        self.name = name
+        self.setting = setting
+    }
+}
+
+
+public struct CreateExistingMemberSettingEntity {
+    let isMarketingNotification: Bool
+    let isVoteNotification: Bool
+    let isMessageNotification: Bool
+        
+    
+    public init(
+        isMarketingNotification: Bool,
+        isVoteNotification: Bool,
+        isMessageNotification: Bool
+    ) {
+        self.isMarketingNotification = isMarketingNotification
+        self.isVoteNotification = isVoteNotification
+        self.isMessageNotification = isMessageNotification
+    }
+}

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Repositories/LoginRepositoryProtocol.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/Repositories/LoginRepositoryProtocol.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 public protocol LoginRepositoryProtocol {
     func createNewMemberToken(body: CreateSignUpTokenRequest) -> Single<CreateSignUpTokenResponseEntity?> // 신규회원
-    func createExistingMember(body: CreateSignUpTokenRequest) -> Single<Bool> // 기존회원
+    func createExistingMember(body: CreateSignUpTokenRequest) -> Single<CreateExistingTokenEntity?> // 기존회원
     func createAccount(body: CreateAccountRequest) -> Single<CreateAccountResponseEntity?> //회원가입
     func fetchSchoolList(query: SchoolListRequestQuery) -> Single<SchoolListResponseEntity?> // 학교 검색
 }

--- a/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateExistingMemberUseCase.swift
+++ b/24th-App-Team-1-iOS/Domain/LoginDomain/Sources/UseCases/CreateExistingMemberUseCase.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxCocoa
 
 public protocol CreateExistingMemberUseCaseProtocol {
-    func execute(body: CreateSignUpTokenRequest) -> Single<Bool>
+    func execute(body: CreateSignUpTokenRequest) -> Single<CreateExistingTokenEntity?>
 }
 
 public final class CreateExistingMemberTokenUseCase: CreateExistingMemberUseCaseProtocol {
@@ -22,7 +22,7 @@ public final class CreateExistingMemberTokenUseCase: CreateExistingMemberUseCase
         self.loginRepository = loginRepository
     }
 
-    public func execute(body: CreateSignUpTokenRequest) -> Single<Bool> {
+    public func execute(body: CreateSignUpTokenRequest) -> Single<CreateExistingTokenEntity?> {
         return loginRepository.createExistingMember(body: body)
     }
     

--- a/24th-App-Team-1-iOS/Domain/VoteDomain/Sources/Entities/CreateVoteReqeuest.swift
+++ b/24th-App-Team-1-iOS/Domain/VoteDomain/Sources/Entities/CreateVoteReqeuest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct CreateVoteReqeuest {
+public struct CreateVoteReqeuest: Codable {
     public let votes: [CreateVoteReqeuest]
     
     public init(votes: [CreateVoteReqeuest]) {
@@ -15,7 +15,7 @@ public struct CreateVoteReqeuest {
     }
 }
 
-public struct CreateVoteItemReqeuest: Equatable {
+public struct CreateVoteItemReqeuest: Codable {
     public let userId: Int
     public let voteOptionId: Int
     

--- a/24th-App-Team-1-iOS/Domain/VoteDomain/Sources/Repositories/VoteRepositoryProtocol.swift
+++ b/24th-App-Team-1-iOS/Domain/VoteDomain/Sources/Repositories/VoteRepositoryProtocol.swift
@@ -10,7 +10,6 @@ import Foundation
 import RxSwift
 
 public protocol VoteRepositoryProtocol {
-    func fetchVoteOptions() -> Single<VoteResponseEntity?>
     func fetchWinnerVoteOptions(query: VoteWinnerRequestQuery) -> Single<VoteWinnerResponseEntity?>
     func uploadFinalVoteResults(body: [CreateVoteItemReqeuest]) -> Single<CreateVoteEntity?>
     func fetchAllVoteResults(query: VoteWinnerRequestQuery) -> Single<VoteAllReponseEntity?>

--- a/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/Reactors/AllMainViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/AllFeature/Sources/Presentation/Reactors/AllMainViewReactor.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-import AllDomain
+import CommonDomain
 import ReactorKit
 
 public final class AllMainViewReactor: Reactor {

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignUpCompleteViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignUpCompleteViewReactor.swift
@@ -83,8 +83,6 @@ public final class SignUpCompleteViewReactor: Reactor {
             
             UserDefaultsManager.shared.refreshToken = accountEntity.refreshToken
             UserDefaultsManager.shared.userName = accountEntity.name
-            UserDefaultsManager.shared.classNumber = currentState.accountRequest.classNumber
-            UserDefaultsManager.shared.grade = currentState.accountRequest.grade
         case let .setExpiredDate(isExpired):
             newState.isExpired = isExpired
         }

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignUpCompleteViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignUpCompleteViewReactor.swift
@@ -79,6 +79,8 @@ public final class SignUpCompleteViewReactor: Reactor {
         case let .setAccountToken(accountEntity):
             newState.accountEntity = accountEntity
             KeychainManager.shared.set(value: accountEntity.accessToken, type: .accessToken)
+            KeychainManager.shared.set(value: accountEntity.refreshToken, type: .refreshToken)
+            
             UserDefaultsManager.shared.refreshToken = accountEntity.refreshToken
             UserDefaultsManager.shared.userName = accountEntity.name
             UserDefaultsManager.shared.classNumber = currentState.accountRequest.classNumber

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignUpCompleteViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignUpCompleteViewReactor.swift
@@ -48,7 +48,7 @@ public final class SignUpCompleteViewReactor: Reactor {
         
         switch action {
         case .viewDidLoad:
-            guard let expiredDate = UserDefaultsManager.shared.expiredDate else { return .empty() }
+            let expiredDate = UserDefaultsManager.shared.expiredDate
             let currentDate = Date.now
                 .toFormatLocaleString(with: .dashYyyyMMddhhmmss)
                 .toLocalDate(with: .dashYyyyMMddhhmmss)

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignUpIntroduceViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/Reactors/SignUpIntroduceViewReactor.swift
@@ -50,6 +50,7 @@ public final class SignUpIntroduceViewReactor: Reactor {
                 imageURL: String,
                 backgroundColor: String
     ) {
+        let backgroundColor = backgroundColor.isEmpty ? "2E2F33" : backgroundColor
         self.updateUserProfileUseCase = updateUserProfileUseCase
         self.createCheckProfanityUseCase = createCheckProfanityUseCase
         self.initialState = State(

--- a/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/SignInViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/LoginFeature/Sources/Presentation/ViewControllers/SignInViewController.swift
@@ -229,8 +229,9 @@ public final class SignInViewController: BaseViewController<SignInViewReactor> {
             }
             .disposed(by: disposeBag)
         
-        reactor.pulse(\.$isExisting)
-            .filter { $0 == true }
+        
+        reactor.pulse(\.$existingAccountResponse)
+            .filter { $0 != nil }
             .bind { _ in
                 NotificationCenter.default.post(name: .showVoteMainViewController, object: nil)
             }

--- a/24th-App-Team-1-iOS/Feature/NotificationFeature/Sources/Presentation/Reactors/NotificationViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/NotificationFeature/Sources/Presentation/Reactors/NotificationViewReactor.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Extensions
 import NotificationDomain
+import CommonDomain
 
 import ReactorKit
 
@@ -16,6 +17,7 @@ public final class NotificationViewReactor: Reactor {
     
     private let fetchUserNotificationItemsUseCase: FetchUserNotificationItemUseCaseProtocol
     private let updateUserNotifcationItemUseCase: UpdateUserNotificationItemUseCaseProtocol
+    private let fetchVoteOptionUseCase: FetchVoteOptionsUseCaseProtocol
     
     public struct State {
         @Pulse var notificationSection: [NotificationSection]
@@ -46,7 +48,8 @@ public final class NotificationViewReactor: Reactor {
     
     public init(
         fetchUserNotificationItemsUseCase: FetchUserNotificationItemUseCaseProtocol,
-        updateUserNotifcationItemUseCase: UpdateUserNotificationItemUseCaseProtocol
+        updateUserNotifcationItemUseCase: UpdateUserNotificationItemUseCaseProtocol,
+        fetchVoteOptionUseCase: FetchVoteOptionsUseCaseProtocol
     ) {
         self.initialState = State(
             notificationSection: [],
@@ -58,10 +61,12 @@ public final class NotificationViewReactor: Reactor {
         )
         self.fetchUserNotificationItemsUseCase = fetchUserNotificationItemsUseCase
         self.updateUserNotifcationItemUseCase = updateUserNotifcationItemUseCase
+        self.fetchVoteOptionUseCase = fetchVoteOptionUseCase
     }
     
     public func mutate(action: Action) -> Observable<Mutation> {
         
+        //TODO: ViewDidLoad에서 데이터(투표) 조회
         switch action {
         case .viewDidLoad:
             let query =  NotificationReqeustQuery(cursorId: 0)

--- a/24th-App-Team-1-iOS/Feature/NotificationFeature/Sources/Presentation/ViewControllers/NotificationViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/NotificationFeature/Sources/Presentation/ViewControllers/NotificationViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import Util
 
 import Then
+import Storage
 import SnapKit
 import RxSwift
 import RxCocoa
@@ -116,6 +117,7 @@ public final class NotificationViewController: BaseViewController<NotificationVi
             .bind(with: self) { owner, response in
                 switch response.0 {
                 case .vote:
+                    UserDefaultsManager.shared.voteRequest = []
                     NotificationCenter.default.post(name: .showVoteProccessController, object: nil)
                 case .voteRecevied:
                     NotificationCenter.default.post(name: .showVoteInventoryViewController, object: nil)

--- a/24th-App-Team-1-iOS/Feature/NotificationFeature/Sources/Presentation/ViewControllers/NotificationViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/NotificationFeature/Sources/Presentation/ViewControllers/NotificationViewController.swift
@@ -112,13 +112,15 @@ public final class NotificationViewController: BaseViewController<NotificationVi
         Observable
             .zip(
                 reactor.pulse(\.$selectedType),
-                reactor.pulse(\.$isCurrentDate)
+                reactor.pulse(\.$isCurrentDate),
+                reactor.pulse(\.$voteResponseEntity)
             )
             .bind(with: self) { owner, response in
                 switch response.0 {
                 case .vote:
                     UserDefaultsManager.shared.voteRequest = []
-                    NotificationCenter.default.post(name: .showVoteProccessController, object: nil)
+                    let userInfo: [AnyHashable: Any] = ["voteOption": response.2]
+                    NotificationCenter.default.post(name: .showVoteProccessController, object: nil, userInfo: userInfo)
                 case .voteRecevied:
                     NotificationCenter.default.post(name: .showVoteInventoryViewController, object: nil)
                 case .voteResults:

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteBeginViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteBeginViewReactor.swift
@@ -7,19 +7,66 @@
 
 import Foundation
 
+import CommonDomain
 import ReactorKit
 
 public final class VoteBeginViewReactor: Reactor {
     public var initialState: State
-    
-    public typealias Action = NoAction
+    private let fetchUserProfileUseCase: FetchUserProfileUseCaseProtocol
     
     public struct State {
-        
+        @Pulse var profileEntity: UserProfileEntity?
+        @Pulse var isLoading: Bool
     }
     
-    public init() {
-        self.initialState = State()
+    public enum Action {
+        case viewDidLoad
+    }
+    
+    public enum Mutation {
+        case setLoading(Bool)
+        case setUserProfileItem(UserProfileEntity)
+    }
+    
+    
+    public init(fetchUserProfileUseCase: FetchUserProfileUseCaseProtocol) {
+        self.fetchUserProfileUseCase = fetchUserProfileUseCase
+        self.initialState = State(isLoading: false)
+    }
+    
+    public func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .viewDidLoad:
+            return fetchUserProfileUseCase
+                .execute()
+                .asObservable()
+                .flatMap { response -> Observable<Mutation> in
+                    guard let response else {
+                        return .just(.setLoading(false))
+                    }
+                    return .concat(
+                        .just(.setLoading(false)),
+                        .just(.setUserProfileItem(response)),
+                        .just(.setLoading(true))
+                        
+                    )
+                    
+                }
+            
+        }
+    }
+    
+    
+    public func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case let .setUserProfileItem(profileEntity):
+            newState.profileEntity = profileEntity
+        case let .setLoading(isLoading):
+            newState.isLoading = isLoading
+        }
+        
+        return newState
     }
     
 }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteBeginViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteBeginViewReactor.swift
@@ -1,0 +1,25 @@
+//
+//  VoteBeginViewReactor.swift
+//  VoteFeature
+//
+//  Created by Kim dohyun on 10/10/24.
+//
+
+import Foundation
+
+import ReactorKit
+
+public final class VoteBeginViewReactor: Reactor {
+    public var initialState: State
+    
+    public typealias Action = NoAction
+    
+    public struct State {
+        
+    }
+    
+    public init() {
+        self.initialState = State()
+    }
+    
+}

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteHomeViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteHomeViewReactor.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Util
-import VoteDomain
+import CommonDomain
 import Storage
 
 import ReactorKit
@@ -15,10 +15,11 @@ import ReactorKit
 public final class VoteHomeViewReactor: Reactor {
     
     private let globalService: WSGlobalServiceProtocol = WSGlobalStateService.shared
+    private let fetchVoteOptionUseCase: FetchVoteOptionsUseCaseProtocol
     public let initialState: State
     
     public struct State {
-
+        @Pulse var voteResponseEntity: VoteResponseEntity?
     }
     
     public enum Action {
@@ -26,11 +27,14 @@ public final class VoteHomeViewReactor: Reactor {
     }
     
     public enum Mutation {
-        
+        case setVoteResponseEntity(VoteResponseEntity?)
     }
     
-    public init() {
-        self.initialState = State()
+    public init(fetchVoteOptionUseCase: FetchVoteOptionsUseCaseProtocol) {
+        self.initialState = State(
+            voteResponseEntity: nil
+        )
+        self.fetchVoteOptionUseCase = fetchVoteOptionUseCase
     }
     
     public func mutate(action: Action) -> Observable<Mutation> {
@@ -38,15 +42,23 @@ public final class VoteHomeViewReactor: Reactor {
         switch action {
         case .didTappedVoteButton:
             UserDefaultsManager.shared.voteRequest = []
-            globalService.event.onNext(.didTappedVoteButton(true))
-                    
-            return .empty()
+            return fetchVoteOptionUseCase.execute()
+                .asObservable()
+                .flatMap { entity -> Observable<Mutation> in
+                    return .just(.setVoteResponseEntity(entity))
+                }
         }
     }
     
     public func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
                 
+        switch mutation {
+        case let .setVoteResponseEntity(voteResponseEntity):
+            newState.voteResponseEntity = voteResponseEntity
+            
+            globalService.event.onNext(.didTappedVoteButton(true, voteOption: voteResponseEntity))
+        }
         return newState
     }
 }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteHomeViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteHomeViewReactor.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Util
 import VoteDomain
+import Storage
 
 import ReactorKit
 
@@ -36,6 +37,7 @@ public final class VoteHomeViewReactor: Reactor {
         
         switch action {
         case .didTappedVoteButton:
+            UserDefaultsManager.shared.voteRequest = []
             globalService.event.onNext(.didTappedVoteButton(true))
                     
             return .empty()

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteMainViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteMainViewReactor.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Util
-import VoteDomain
+import CommonDomain
 
 import ReactorKit
 
@@ -23,13 +23,14 @@ public final class VoteMainViewReactor: Reactor {
         var voteTypes: VoteTypes
         @Pulse var isShowEffectView: Bool
         @Pulse var isSelected: Bool
+        @Pulse var voteResponseEntity: VoteResponseEntity?
         @Pulse var isProfileChanged: Bool
         @Pulse var isProfileUpdate: Bool
     }
     
     public enum Mutation {
         case setVoteTypes(VoteTypes)
-        case setSelectedVoteButton(Bool)
+        case setSelectedVoteButton(Bool, VoteResponseEntity?)
         case setShowEffectView(Bool)
         case setUserProfileUpdate(Bool)
     }
@@ -48,8 +49,8 @@ public final class VoteMainViewReactor: Reactor {
         let fetchVoteResponse = globalService.event
             .flatMap { event -> Observable<Mutation> in
                 switch event {
-                case let .didTappedVoteButton(isSelected):
-                    return .just(.setSelectedVoteButton(isSelected))
+                case let .didTappedVoteButton(isSelected, response):
+                    return .just(.setSelectedVoteButton(isSelected, response))
                 case .didTappedResultButton:
                     return .just(.setShowEffectView(true))
                 case let .didTappedIntroduceButton(isUpdate):
@@ -71,8 +72,9 @@ public final class VoteMainViewReactor: Reactor {
     public func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
-        case let .setSelectedVoteButton(isSelected):
+        case let .setSelectedVoteButton(isSelected, response):
             newState.isSelected = isSelected
+            newState.voteResponseEntity = response
         case let .setVoteTypes(voteTypes):
             globalService.event.onNext(.toggleStatus(voteTypes))
             newState.voteTypes = voteTypes

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteProcessViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteProcessViewReactor.swift
@@ -9,6 +9,7 @@ import Foundation
 import Util
 import VoteDomain
 import CommonDomain
+import Storage
 
 import ReactorKit
 
@@ -22,7 +23,6 @@ public final class VoteProcessViewReactor: Reactor {
         @Pulse var questionSection: [VoteProcessSection]
         @Pulse var voteResponseEntity: VoteResponseEntity?
         @Pulse var voteUserEntity: VoteUserEntity?
-        @Pulse var voteOptionsStub: [CreateVoteItemReqeuest]
         @Pulse var processCount: Int
         @Pulse var reportEntity: CreateReportUserEntity?
         @Pulse var isLoading: Bool
@@ -36,6 +36,7 @@ public final class VoteProcessViewReactor: Reactor {
         case didTappedQuestionItem(Int)
         case didTappedResultButton
         case didTappedReportButton
+        case didTappedLeftBarButtonItem
     }
     
     public enum Mutation {
@@ -43,8 +44,7 @@ public final class VoteProcessViewReactor: Reactor {
         case setQuestionRowItems([VoteProcessItem])
         case setVoteOptionItems(VoteItemEntity)
         case setVoteInviteView(Bool)
-        case addVoteOptionStub(CreateVoteItemReqeuest)
-        case updateVoteOptionStub(Int, CreateVoteItemReqeuest)
+        case setProcessCount(Int)
         case setVoteUserItems(VoteUserEntity)
         case setVoteResponseItems(VoteResponseEntity?)
         case setCreateVoteItems(CreateVoteEntity)
@@ -57,15 +57,12 @@ public final class VoteProcessViewReactor: Reactor {
         createVoteUseCase: CreateVoteUseCaseProtocol,
         createUserReportUseCase: CreateReportUserUseCaseProtocol,
         fetchVoteOptionsUseCase: FetchVoteOptionsUseCaseProtocol,
-        voteResponseEntity: VoteResponseEntity? = nil,
-        voteOptionStub: [CreateVoteItemReqeuest] = [],
-        processCount: Int = 1
+        voteResponseEntity: VoteResponseEntity? = nil
     ) {
         self.initialState = State(
             questionSection: [.votePrcessInfo([])],
             voteResponseEntity: voteResponseEntity,
-            voteOptionsStub: voteOptionStub,
-            processCount: processCount,
+            processCount: 1,
             isLoading: false,
             isInviteView: false
         )
@@ -75,13 +72,12 @@ public final class VoteProcessViewReactor: Reactor {
     }
     
     public func mutate(action: Action) -> Observable<Mutation> {
-        let index = currentState.processCount - 1
+        let index = UserDefaultsManager.shared.voteRequest.count
         switch action {
         case .viewDidLoad:
             var voteSectionItems: [VoteProcessItem] = []
-            
-            guard currentState.processCount == 1 else {
-                
+            let processCount = UserDefaultsManager.shared.voteRequest.count + 1
+            guard processCount == 1 else {
                 guard let response = currentState.voteResponseEntity?.response[index] else {
                     return .concat(
                         .just(.setLoading(false)),
@@ -89,7 +85,6 @@ public final class VoteProcessViewReactor: Reactor {
                         .just(.setLoading(true))
                     )
                 }
-                
                 response.voteInfo.forEach {
                     voteSectionItems.append(
                         .voteQuestionItem(
@@ -105,6 +100,7 @@ public final class VoteProcessViewReactor: Reactor {
                     .just(.setLoading(false)),
                     .just(.setVoteInviteView(true)),
                     .just(.setQuestionRowItems(voteSectionItems)),
+                    .just(.setProcessCount(processCount)),
                     .just(.setVoteUserItems(response.userInfo)),
                     .just(.setVoteResponseItems(currentState.voteResponseEntity)),
                     .just(.setLoading(true))
@@ -150,24 +146,25 @@ public final class VoteProcessViewReactor: Reactor {
             
         case let .didTappedQuestionItem(row):
 
-            let index =  currentState.processCount - 1
+            let index = UserDefaultsManager.shared.voteRequest.count
             guard let request = currentState.voteResponseEntity?.response[index] else { return .empty() }
+            var currentOptions = UserDefaultsManager.shared.voteRequest
             
             let voteOption = CreateVoteItemReqeuest(
                 userId: request.userInfo.id,
                 voteOptionId: request.voteInfo[row].id
             )
             
-            if index < currentState.voteOptionsStub.count {
-                return .just(.updateVoteOptionStub(index, voteOption))
+            if index < currentOptions.count {
+                UserDefaultsManager.shared.voteRequest[index] = voteOption
             } else {
-                return .just(.addVoteOptionStub(voteOption))
+                UserDefaultsManager.shared.voteRequest.append(voteOption)
             }
+            return .empty()
             
         case .didTappedResultButton:
             
-            let requestBody = currentState.voteOptionsStub
-            
+            let requestBody = UserDefaultsManager.shared.voteRequest
             return createVoteUseCase
                 .execute(body: requestBody)
                 .asObservable()
@@ -187,6 +184,13 @@ public final class VoteProcessViewReactor: Reactor {
                 .flatMap { entity -> Observable<Mutation> in
                     return .just(.setReportItem(entity))
                 }
+        case .didTappedLeftBarButtonItem:
+            guard UserDefaultsManager.shared.voteRequest.isEmpty else {
+                let index = UserDefaultsManager.shared.voteRequest.count - 1
+                UserDefaultsManager.shared.voteRequest.remove(at: index)
+                return .empty()
+            }
+            return .empty()
         }
     }
     
@@ -202,12 +206,6 @@ public final class VoteProcessViewReactor: Reactor {
         case let .setVoteOptionItems(voteItemEntity):
             newState.voteItemEntity = voteItemEntity
             
-        case let .addVoteOptionStub(voteOptionStub):
-            newState.voteOptionsStub.append(voteOptionStub)
-            
-        case let .updateVoteOptionStub(index, voteOptionStub):
-            newState.voteOptionsStub[index] = voteOptionStub
-            
         case let .setVoteUserItems(voteUserEntity):
             newState.voteUserEntity = voteUserEntity
             
@@ -222,6 +220,10 @@ public final class VoteProcessViewReactor: Reactor {
             
         case let .setVoteInviteView(isInviteView):
             newState.isInviteView = isInviteView
+            
+        case let .setProcessCount(processCount):
+            
+            newState.processCount = processCount
         }
         return newState
     }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteBeginViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteBeginViewController.swift
@@ -1,50 +1,43 @@
 //
-//  VoteBeginView.swift
+//  VoteBeginViewController.swift
 //  VoteFeature
 //
-//  Created by Kim dohyun on 7/16/24.
+//  Created by Kim dohyun on 10/10/24.
 //
 
-import DesignSystem
 import UIKit
-import Util
+import DesignSystem
 import Storage
+import Util
 
-import Then
 import SnapKit
+import Then
 import RxSwift
 import RxCocoa
-import ReactorKit
+
 
 fileprivate typealias VoteBeginStr = VoteStrings
-public final class VoteBeginView: UIView {
-
+public final class VoteBeginViewController: BaseViewController<VoteBeginViewReactor> {
     //MARK: - Properties
     private let beginInfoLabel: WSLabel = WSLabel(wsFont: .Header01)
     let inviteButton: WSButton = WSButton(wsButtonType: .default(12))
     private let beginImageView: UIImageView = UIImageView()
     
-    //MARK: - LifeCycle
     
-    
-    public override init(frame: CGRect) {
-        super.init(frame: frame)
-        setupUI()
-        setupAttributes()
-        setupAutoLayout()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    public override func viewDidLoad() {
+        super.viewDidLoad()
     }
     
     //MARK: - Configure
-    public func setupUI() {
-        addSubviews(beginInfoLabel, beginImageView, inviteButton)
+    public override func setupUI() {
+        super.setupUI()
+        view.addSubviews(beginInfoLabel, beginImageView, inviteButton)
     }
-    public func setupAutoLayout() {
+    public override func setupAutoLayout() {
+        super.setupAutoLayout()
+        
         beginInfoLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(60)
+            $0.top.equalTo(navigationBar.snp.bottom)
             $0.horizontalEdges.equalToSuperview().inset(30)
             $0.height.equalTo(60)
         }
@@ -62,8 +55,8 @@ public final class VoteBeginView: UIView {
         }
     }
     
-    public func setupAttributes() {
-        
+    public override func setupAttributes() {
+        super.setupAttributes()
         beginInfoLabel.do {
             guard let grade = UserDefaultsManager.shared.grade,
                   let classNumber = UserDefaultsManager.shared.classNumber else { return }
@@ -78,5 +71,22 @@ public final class VoteBeginView: UIView {
         inviteButton.do {
             $0.setupButton(text: VoteBeginStr.voteInviteButtonText)
         }
+        
+        navigationBar.do {
+            $0.setNavigationBarUI(
+                property: .leftIcon(DesignSystemAsset.Images.arrow.image)
+            )
+            $0.setNavigationBarAutoLayout(property: .leftIcon)
+        }
+    }
+    
+    public override func bind(reactor: VoteBeginViewReactor) {
+        inviteButton
+            .rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                owner.shareToKakaoTalk()
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteBeginViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteBeginViewController.swift
@@ -28,6 +28,11 @@ public final class VoteBeginViewController: BaseViewController<VoteBeginViewReac
         super.viewDidLoad()
     }
     
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NotificationCenter.default.post(name: .hideTabBar, object: nil)
+    }
+    
     //MARK: - Configure
     public override func setupUI() {
         super.setupUI()
@@ -81,6 +86,7 @@ public final class VoteBeginViewController: BaseViewController<VoteBeginViewReac
     }
     
     public override func bind(reactor: VoteBeginViewReactor) {
+        super.bind(reactor: reactor)
         inviteButton
             .rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteBeginViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteBeginViewController.swift
@@ -63,9 +63,6 @@ public final class VoteBeginViewController: BaseViewController<VoteBeginViewReac
     public override func setupAttributes() {
         super.setupAttributes()
         beginInfoLabel.do {
-            guard let grade = UserDefaultsManager.shared.grade,
-                  let classNumber = UserDefaultsManager.shared.classNumber else { return }
-            $0.text = "투표할 수 있는\n\(grade)학년 \(classNumber)반 친구들이 부족해요"
             $0.textColor = DesignSystemAsset.Colors.gray100.color
         }
         
@@ -87,12 +84,24 @@ public final class VoteBeginViewController: BaseViewController<VoteBeginViewReac
     
     public override func bind(reactor: VoteBeginViewReactor) {
         super.bind(reactor: reactor)
+        
+        Observable.just(())
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         inviteButton
             .rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind(with: self) { owner, _ in
                 owner.shareToKakaoTalk()
             }
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.profileEntity }
+            .map { "투표할 수 있는\n\($0.grade)학년 \($0.classNumber)반 친구들이 부족해요" }
+            .bind(to: beginInfoLabel.rx.text)
             .disposed(by: disposeBag)
     }
 }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteMainViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteMainViewController.swift
@@ -72,6 +72,25 @@ public final class VoteMainViewController: BaseViewController<VoteMainViewReacto
             }
             .disposed(by: disposeBag)
         
+        reactor.pulse(\.$voteResponseEntity)
+            .compactMap { $0 }
+            .filter { $0.response.isEmpty }
+            .bind(with: self) { owner, _ in
+                let voteBeginViewController = DependencyContainer.shared.injector.resolve(VoteBeginViewController.self)
+                owner.navigationController?.pushViewController(voteBeginViewController, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$voteResponseEntity)
+            .compactMap { $0 }
+            .filter { !$0.response.isEmpty }
+            .bind(with: self) { owner, entity in
+                let voteProcessViewController = DependencyContainer.shared.injector.resolve(VoteProcessViewController.self, argument: entity)
+                owner.navigationController?.pushViewController(voteProcessViewController, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        
         reactor.state.map { $0.isProfileChanged }
             .filter { $0 == false }
             .take(1)
@@ -127,13 +146,5 @@ public final class VoteMainViewController: BaseViewController<VoteMainViewReacto
             }
             .disposed(by: disposeBag)
         
-        
-        reactor.pulse(\.$isSelected)
-            .filter { $0 == true }
-            .bind(with: self) { owner, _ in
-                let voteProcessViewController = DependencyContainer.shared.injector.resolve(VoteProcessViewController.self)
-                owner.navigationController?.pushViewController(voteProcessViewController, animated: true)
-            }
-            .disposed(by: disposeBag)
     }
 }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteMainViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteMainViewController.swift
@@ -73,17 +73,18 @@ public final class VoteMainViewController: BaseViewController<VoteMainViewReacto
             .disposed(by: disposeBag)
         
         reactor.pulse(\.$voteResponseEntity)
-            .compactMap { $0 }
-            .filter { $0.response.isEmpty }
+            .compactMap { $0?.response }
+            .filter { $0.isEmpty }
             .bind(with: self) { owner, _ in
                 let voteBeginViewController = DependencyContainer.shared.injector.resolve(VoteBeginViewController.self)
                 owner.navigationController?.pushViewController(voteBeginViewController, animated: true)
             }
             .disposed(by: disposeBag)
         
+        
         reactor.pulse(\.$voteResponseEntity)
-            .compactMap { $0 }
-            .filter { !$0.response.isEmpty }
+            .map { $0 }
+            .filter { !($0?.response.isEmpty ?? true) }
             .bind(with: self) { owner, entity in
                 let voteProcessViewController = DependencyContainer.shared.injector.resolve(VoteProcessViewController.self, argument: entity)
                 owner.navigationController?.pushViewController(voteProcessViewController, animated: true)

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteProcessViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteProcessViewController.swift
@@ -147,16 +147,6 @@ public final class VoteProcessViewController: BaseViewController<VoteProcessView
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        reactor.pulse(\.$isInviteView)
-            .distinctUntilChanged()
-            .filter { $0 == false}
-            .observe(on: MainScheduler.asyncInstance)
-            .bind(with: self) { owner, _ in
-                let voteBeginViewController = DependencyContainer.shared.injector.resolve(VoteBeginViewController.self)
-                owner.navigationController?.pushViewController(voteBeginViewController, animated: true)
-            }
-            .disposed(by: disposeBag)
-        
         navigationBar.rightBarButton
             .rx.tap
             .throttle(.microseconds(300), scheduler: MainScheduler.instance)

--- a/24th-App-Team-1-iOS/Service/AllService/Sources/Repository/ProfileRepository.swift
+++ b/24th-App-Team-1-iOS/Service/AllService/Sources/Repository/ProfileRepository.swift
@@ -22,17 +22,6 @@ public final class ProfileRepository: ProfileRepositoryProtocol {
     
     public init() { }
  
-    public func fetchUserProfileItems() -> Single<UserProfileEntity?> {
-        let endPoint = ProfileEndPoint.fetchUserProfile
-        
-        return networkService.request(endPoint: endPoint)
-            .asObservable()
-            .decodeMap(UserProfileResponseDTO.self)
-            .logErrorIfDetected(category: Network.error)
-            .map { $0.toDomain() }
-            .asSingle()
-    }
-    
     public func fetchUserAlarmItems() -> Single<UserAlarmEntity?> {
         let endPoint = ProfileEndPoint.fetchNotification
         return networkService.request(endPoint: endPoint)

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/UserProfileResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/UserProfileResponseDTO.swift
@@ -1,13 +1,13 @@
 //
 //  UserProfileResponseDTO.swift
-//  AlleService
+//  CommonService
 //
-//  Created by Kim dohyun on 8/12/24.
+//  Created by 김도현 on 10/16/24.
 //
 
 import Foundation
 
-import AllDomain
+import CommonDomain
 
 public struct UserProfileResponseDTO: Decodable {
     public let id: Int

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/VoteOptionResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/VoteOptionResponseDTO.swift
@@ -1,13 +1,13 @@
 //
 //  VoteOptionResponseDTO.swift
-//  VoteService
+//  CommonService
 //
-//  Created by Kim dohyun on 7/22/24.
+//  Created by Kim dohyun on 10/10/24.
 //
 
 import Foundation
 
-import VoteDomain
+import CommonDomain
 
 public struct VoteResponseDTO: Decodable {
     public let response: [VoteItemResponseDTO]

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/Repository/CommonRepository.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/Repository/CommonRepository.swift
@@ -21,6 +21,18 @@ public final class CommonRepository: CommonRepositoryProtocol {
     
     public init() { }
     
+    public func fetchUserProfileItems() -> Single<UserProfileEntity?> {
+        let endPoint = CommonEndPoint.fetchUserProfile
+        
+        return networkService.request(endPoint: endPoint)
+            .asObservable()
+            .decodeMap(UserProfileResponseDTO.self)
+            .logErrorIfDetected(category: Network.error)
+            .map { $0.toDomain() }
+            .asSingle()
+    }
+    
+    
     
     public func updateUserProfileItem(body: UpdateUserProfileRequest) -> Single<Bool> {
         

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/Repository/CommonRepository.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/Repository/CommonRepository.swift
@@ -80,4 +80,14 @@ public final class CommonRepository: CommonRepositoryProtocol {
             .map { $0.toDomain() }
             .asSingle()
     }
+    
+    public func fetchVoteOptions() -> Single<VoteResponseEntity?> {
+        let endPoint = CommonEndPoint.fetchVoteOptions
+        return networkService.request(endPoint: endPoint)
+            .asObservable()
+            .logErrorIfDetected(category: Network.error)
+            .decodeMap(VoteResponseDTO.self)
+            .map { $0.toDomain() }
+            .asSingle()
+    }
 }

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateExistingTokenResponseDTO.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/DataMapping/CreateExistingTokenResponseDTO.swift
@@ -1,0 +1,58 @@
+//
+//  CreateExistingTokenResponseDTO.swift
+//  LoginService
+//
+//  Created by 김도현 on 10/16/24.
+//
+
+import Foundation
+
+import LoginDomain
+import Extensions
+
+
+public struct CreateExistingTokenResponseDTO: Decodable {
+    let isProfileChanged: Bool
+    let refreshToken: String
+    let refreshTokenExpiredAt: String
+    let accessToken: String
+    let name: String
+    let setting: CreateExistingMemberSettingResponseDTO
+}
+
+
+
+extension CreateExistingTokenResponseDTO {
+    public struct CreateExistingMemberSettingResponseDTO: Decodable {
+        let isMarketingNotification: Bool
+        let isVoteNotification: Bool
+        let isMessageNotification: Bool
+    }
+}
+
+extension CreateExistingTokenResponseDTO {
+    func toDomain() -> CreateExistingTokenEntity {
+        return .init(
+            isProfileChanged: isProfileChanged,
+            refreshToken: refreshToken,
+            refreshTokenExpiredAt: refreshTokenExpiredAt.toDate(with: .dashYyyyMMddhhmmss),
+            accessToken: accessToken,
+            name: name,
+            setting: setting.toDomain()
+        )
+    }
+}
+
+extension CreateExistingTokenResponseDTO.CreateExistingMemberSettingResponseDTO {
+    func toDomain() -> CreateExistingMemberSettingEntity {
+        return .init(
+            isMarketingNotification: isMarketingNotification,
+            isVoteNotification: isVoteNotification,
+            isMessageNotification: isMessageNotification
+        )
+    }
+}
+
+
+
+

--- a/24th-App-Team-1-iOS/Service/LoginService/Sources/Repository/LoginRepository.swift
+++ b/24th-App-Team-1-iOS/Service/LoginService/Sources/Repository/LoginRepository.swift
@@ -33,15 +33,15 @@ public final class LoginRepository: LoginRepositoryProtocol {
             .asSingle()
     }
     
-    public func createExistingMember(body: CreateSignUpTokenRequest) -> Single<Bool> {
+    public func createExistingMember(body: CreateSignUpTokenRequest) -> Single<CreateExistingTokenEntity?> {
         let body = CreateSignUpTokenRequestDTO(socialType: body.socialType, authorizationCode: body.authorizationCode, identityToken: body.identityToken, fcmToken: body.fcmToken)
         let endPoint = LoginEndPoint.createSocialLogin(body)
         
         return networkService.request(endPoint: endPoint)
             .asObservable()
-            .map { _ in true }
-            .catchAndReturn(false)
+            .decodeMap(CreateExistingTokenResponseDTO.self)
             .logErrorIfDetected(category: Network.error)
+            .map { $0.toDomain() }
             .asSingle()
     }
     

--- a/24th-App-Team-1-iOS/Service/VoteService/Sources/Repository/VoteRepository.swift
+++ b/24th-App-Team-1-iOS/Service/VoteService/Sources/Repository/VoteRepository.swift
@@ -20,16 +20,6 @@ public final class VoteRepository: VoteRepositoryProtocol {
     private let networkService: WSNetworkServiceProtocol = WSNetworkService()
     
     public init() { }
-        
-    public func fetchVoteOptions() -> Single<VoteResponseEntity?> {
-        let endPoint = VoteEndPoint.fetchVoteOptions
-        return networkService.request(endPoint: endPoint)
-            .asObservable()
-            .logErrorIfDetected(category: Network.error)
-            .decodeMap(VoteResponseDTO.self)
-            .map { $0.toDomain() }
-            .asSingle()
-    }
     
     public func fetchWinnerVoteOptions(query: VoteWinnerRequestQuery) -> Single<VoteWinnerResponseEntity?> {
         let query = VoteWinnerRequestDTO(date: query.date)

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
@@ -19,9 +19,9 @@ extension InfoPlist {
         
         
         var basePlist: [String: Plist.Value] = [
-            "CFBundleDisplayName": .string("wespot"),
+            "CFBundleDisplayName": .string("Wespot"),
             "UIUserInterfaceStyle": .string("Dark"),
-            "CFBundleShortVersionString": .string("1.1.0"),
+            "CFBundleShortVersionString": .string("1.2.0"),
             "CFBundleVersion": .string("1"),
             "UILaunchStoryboardName": .string("LaunchScreen"),
             "UISupportedInterfaceOrientations": .array([.string("UIInterfaceOrientationPortrait")]),


### PR DESCRIPTION
## 작업 내용

- [x] 투표 진행 시 잘못된 투표 카운트 횟수를 화면에 바인딩 처리하는 이슈 수정 
- [x] 만료된 AccessToken으로 서버 요청하는 이슈 수정
- [x] `WSNetworkMonitor` 에서 `didParseResponse` 메서드 호출 안되는 이슈 수정
- [x] `VoteOptions` 없을 경우 초대하기 화면으로 이동하는 로직 추가
- [x] 친구 초대하기 화면에서 잘못된 학년, 반 UI 보여주는 이슈 수정
- [x] 친구 초대하기 화면 상단 NavigationBar 추가

<br/><br/>
## 고민점 및 해결 방법 
- `투표하기 API` 및 `프로필 조회 API` Common 모듈로 로직 수정
- 친구 초대하기 화면에서 프로필 조회를 통해 학년, 반 값 조회 (기존 UserDefaults)를 통해 조회를 했지만 앱 삭제시 데이터 사라지기 때문에 서버에서 호출



close: #149 
