### PR TITLE
fix: 알림 화면 전환 issue 수정해요

### DIFF
--- a/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
+++ b/24th-App-Team-1-iOS/App/Sources/Applications/SceneDelegate.swift
@@ -103,9 +103,6 @@ extension SceneDelegate {
     
     //TODO: Coordinator 패턴으로 수정
     private func setupViewControllers() {
-        guard let topViewController = self.window?.rootViewController?.topMostViewController() else {
-            return
-        }
         
         NotificationCenter.default.addObserver(forName: .showProfileImageViewController, object: nil, queue: .main) { [weak self] _ in
             guard let self else { return }
@@ -130,37 +127,45 @@ extension SceneDelegate {
             self.window?.rootViewController = UINavigationController(rootViewController: signInViewController)
         }
         
-        NotificationCenter.default.addObserver(forName: .showNotifcationViewController, object: nil, queue: .main) { _ in
+        NotificationCenter.default.addObserver(forName: .showNotifcationViewController, object: nil, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            let topViewController = self.window?.rootViewController?.topMostViewController()
             let notificationViewController = DependencyContainer.shared.injector.resolve(NotificationViewController.self)
-            topViewController.navigationController?.pushViewController(notificationViewController, animated: true)
+            topViewController?.navigationController?.pushViewController(notificationViewController, animated: true)
         }
         
-        NotificationCenter.default.addObserver(forName: .showVoteProccessController, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .showVoteProccessController, object: nil, queue: .main) { [weak self] notification in
+            guard let self else { return }
+            let topViewController = self.window?.rootViewController?.topMostViewController()
             let voteOption = notification.userInfo?["voteOption"] as? VoteResponseEntity
             if !(voteOption?.response.isEmpty ?? true) {
                 let voteProcessViewController = DependencyContainer.shared.injector.resolve(VoteProcessViewController.self, argument: voteOption)
-                topViewController.navigationController?.pushViewController(voteProcessViewController, animated: true)
+                topViewController?.navigationController?.pushViewController(voteProcessViewController, animated: true)
             } else {
                 let voteBeginViewController = DependencyContainer.shared.injector.resolve(VoteBeginViewController.self)
-                topViewController.navigationController?.pushViewController(voteBeginViewController, animated: true)
+                topViewController?.navigationController?.pushViewController(voteBeginViewController, animated: true)
             }
         }
         
-        NotificationCenter.default.addObserver(forName: .showVoteInventoryViewController, object: nil, queue: .main) { _ in
+        NotificationCenter.default.addObserver(forName: .showVoteInventoryViewController, object: nil, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            let topViewController = self.window?.rootViewController?.topMostViewController()
             let voteInventoryViewController = DependencyContainer.shared.injector.resolve(VoteInventoryViewController.self)
-            topViewController.navigationController?.pushViewController(voteInventoryViewController, animated: true)
+            topViewController?.navigationController?.pushViewController(voteInventoryViewController, animated: true)
         }
         
-        NotificationCenter.default.addObserver(forName: .showVoteCompleteViewController, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .showVoteCompleteViewController, object: nil, queue: .main) { [weak self] notification in
+            guard let self,
+                  let isCurrnetDate = notification.userInfo?["isCurrnetDate"] as? Bool else { return }
+            let topViewController = self.window?.rootViewController?.topMostViewController()
             
-            guard let isCurrnetDate = notification.userInfo?["isCurrnetDate"] as? Bool else { return }
             
             if isCurrnetDate {
                 let voteCompleteViewController = DependencyContainer.shared.injector.resolve(VoteCompleteViewController.self)
-                topViewController.navigationController?.pushViewController(voteCompleteViewController, animated: true)
+                topViewController?.navigationController?.pushViewController(voteCompleteViewController, animated: true)
             } else {
                 let voteEffectViewController = DependencyContainer.shared.injector.resolve(VoteEffectViewController.self)
-                topViewController.navigationController?.pushViewController(voteEffectViewController, animated: true)
+                topViewController?.navigationController?.pushViewController(voteEffectViewController, animated: true)
             }
             
         }

--- a/24th-App-Team-1-iOS/Core/Extensions/Sources/UIViewController+Extensions.swift
+++ b/24th-App-Team-1-iOS/Core/Extensions/Sources/UIViewController+Extensions.swift
@@ -53,14 +53,14 @@ public extension UIViewController {
     }
     
     func topMostViewController() -> UIViewController? {
-        if let presentedViewController = self.presentedViewController {
-            return presentedViewController.topMostViewController()
+        if let tabBarController = self as? UITabBarController {
+            return tabBarController.selectedViewController?.topMostViewController()
         }
         if let navigationController = self as? UINavigationController {
             return navigationController.topViewController?.topMostViewController()
         }
-        if let tabBarController = self as? UITabBarController {
-            return tabBarController.selectedViewController?.topMostViewController()
+        if let presentedViewController = self.presentedViewController {
+            return presentedViewController.topMostViewController()
         }
         return self
     }

--- a/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkService.swift
+++ b/24th-App-Team-1-iOS/Core/Networking/Sources/Implement/implementation/ServiceImpl/WSNetworkService.swift
@@ -13,7 +13,7 @@ import RxSwift
 public final class WSNetworkService: WSNetworkServiceProtocol {
     
     //MARK: Property
-    private let session: Session = {
+    private static let session: Session = {
         let networkMonitor: WSNetworkMonitor = WSNetworkMonitor()
         let networkConfigure: URLSessionConfiguration = URLSessionConfiguration.af.default
         let interceptor = WSNetworkInterceptor()
@@ -30,8 +30,8 @@ public final class WSNetworkService: WSNetworkServiceProtocol {
     
     //MARK: Functions
     public func request(endPoint: URLRequestConvertible) -> Single<Data> {
-        return Single<Data>.create { [weak self] single in
-            let task = self?.session.request(endPoint)
+        return Single<Data>.create { single in
+            WSNetworkService.session.request(endPoint)
                 .responseData { response in
                     switch response.result {
                     case let .success(response):
@@ -49,9 +49,7 @@ public final class WSNetworkService: WSNetworkServiceProtocol {
                         }
                     }
                 }
-            return Disposables.create {
-                task?.cancel()
-            }
+            return Disposables.create()
         }
     }
 }

--- a/24th-App-Team-1-iOS/Feature/MessageFeature/Sources/Presentation/ViewControllers/MessageMainViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/MessageFeature/Sources/Presentation/ViewControllers/MessageMainViewController.swift
@@ -25,6 +25,11 @@ public final class MessageMainViewController: BaseViewController<MessageMainView
         super.viewDidLoad()
         
     }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NotificationCenter.default.post(name: .showTabBar, object: nil)
+    }
 
     //MARK: - Configure
     public override func setupUI() {
@@ -60,6 +65,16 @@ public final class MessageMainViewController: BaseViewController<MessageMainView
                 owner.noticeAlertViewController()
             }
             .disposed(by: disposeBag)
+        
+        
+        navigationBar.rightBarButton
+            .rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .bind(with: self) { owner, _ in
+                NotificationCenter.default.post(name: .showNotifcationViewController, object: nil)
+            }
+            .disposed(by: disposeBag)
+        
 
     }
 }

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteProcessViewReactor.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/Reactors/VoteProcessViewReactor.swift
@@ -138,7 +138,7 @@ public final class VoteProcessViewReactor: Reactor {
             
         case .didTappedReportButton:
             
-            let userReportQuery = CreateUserReportRequest(type: CreateUserReportType.message.rawValue, targetId: currentState.voteUserEntity?.id ?? 0)
+            let userReportQuery = CreateUserReportRequest(type: CreateUserReportType.vote.rawValue, targetId: currentState.voteUserEntity?.id ?? 0)
             return createUserReportUseCase
                 .execute(body: userReportQuery)
                 .asObservable()

--- a/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteMainViewController.swift
+++ b/24th-App-Team-1-iOS/Feature/VoteFeature/Sources/Presentation/ViewControllers/VoteMainViewController.swift
@@ -126,7 +126,6 @@ public final class VoteMainViewController: BaseViewController<VoteMainViewReacto
         
         navigationBar.rightBarButton
             .rx.tap
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .bind(with: self) { owner, _ in
                 NotificationCenter.default.post(name: .showNotifcationViewController, object: nil)
             }

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/CreateUserReportRequestDTO.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/DataMapping/CreateUserReportRequestDTO.swift
@@ -9,11 +9,11 @@ import Foundation
 
 
 public struct CreateUserReportRequestDTO: Encodable {
-    public let type: String
+    public let reportType: String
     public let targetId: Int
     
-    public init(type: String, targetId: Int) {
-        self.type = type
+    public init(reportType: String, targetId: Int) {
+        self.reportType = reportType
         self.targetId = targetId
     }
 }

--- a/24th-App-Team-1-iOS/Service/CommonService/Sources/Repository/CommonRepository.swift
+++ b/24th-App-Team-1-iOS/Service/CommonService/Sources/Repository/CommonRepository.swift
@@ -82,7 +82,7 @@ public final class CommonRepository: CommonRepositoryProtocol {
     }
     
     public func createReportUserItem(body: CreateUserReportRequest) -> Single<CreateReportUserEntity?> {
-        let body = CreateUserReportRequestDTO(type: body.type, targetId: body.targetId)
+        let body = CreateUserReportRequestDTO(reportType: body.type, targetId: body.targetId)
         let endPoint = CommonEndPoint.createUserReport(body)
         
         return networkService.request(endPoint: endPoint)

--- a/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
+++ b/24th-App-Team-1-iOS/Tuist/ProjectDescriptionHelpers/InfoPlist+Templates.swift
@@ -19,9 +19,9 @@ extension InfoPlist {
         
         
         var basePlist: [String: Plist.Value] = [
-            "CFBundleDisplayName": .string("Wespot"),
+            "CFBundleDisplayName": .string("WeSpot"),
             "UIUserInterfaceStyle": .string("Dark"),
-            "CFBundleShortVersionString": .string("1.2.0"),
+            "CFBundleShortVersionString": .string("1.2.1"),
             "CFBundleVersion": .string("1"),
             "UILaunchStoryboardName": .string("LaunchScreen"),
             "UISupportedInterfaceOrientations": .array([.string("UIInterfaceOrientationPortrait")]),


### PR DESCRIPTION
## 작업 내용

- [x] `SceneDelegate` 내부 알림 화면 전환 로직 수정
- [x] `VoteMainViewController` `throttole` 연산자 제거
- [x] `MessageMainViewController` 알림 화면 전환 로직 추가
- [x] `CreateUserReportRequestDTO` 내부 Property 변수명 수정
- [x] `WSNetworkService` `Session` 객체 타입 프로퍼티로 수정
- [x] `Tuist` `CFBundleDisplayName` `WeSpot`으로 수정 및 `1.2.1`로 앱 버전 수정

## 고민점 및 해결 방법 (Optional)
- `SceneDelegate`에서 많은 화면 전환 로직 들이 있기 때문에 별도 Module을 추가해서 Coordinator 패턴을 도입하는 것이 좋을 것 같음



close: #151 
